### PR TITLE
Removed exclamation from ansible task name

### DIFF
--- a/roles/sat6repro/tasks/main.yml
+++ b/roles/sat6repro/tasks/main.yml
@@ -103,6 +103,6 @@
   file: src=/opt/rh/ruby193/root/usr/share/gems/gems/katello-2.2.0.93/public/assets/bastion_katello dest=/usr/share/foreman/public/assets/bastion_katello
   when: satelliteversion == 6.1
 
-- name: Reset katello index (Note: this might take hours!!!!!)
+- name: Reset katello index - Note that this might take hours
   command: foreman-rake katello:reindex --trace
   when: run_katello_reindex


### PR DESCRIPTION
The colon in task name caused parsing issues in ansible run.