### PR TITLE
Remove rsync install task on the Ansible Control node.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,17 @@ Ideally, you need two hosts to run this project:
 - RHEL 6
 - RHEL 7
 
-1. Install `ansible` package on the Control node. For RHEL boxes, [access to EPEL] (https://access.redhat.com/solutions/3358) is required.
+1. Installation of required packages:
+   a. Install `ansible` package on the Control node. For RHEL boxes, [access to EPEL] (https://access.redhat.com/solutions/3358) is required.
 
-  ```console
-     # yum install -y ansible
-  ```
+      ```console
+        # yum install -y ansible
+      ```
+   b. Since the playbook uses `synchronize` module, install `rsync` package on the Ansible Control node.
+
+      ```console
+        # yum install -y rsync
+      ```
 2. git clone this project.
 
   ```console
@@ -41,6 +47,7 @@ Now you can proceed to any of the following tasks:
 <!-- Do not change link names as they are linked to from external sites! -->
  * [Cloning a Satellite host](#cloning-a-satellite-host)
  * [Changing the hostname of a Satellite host](#changing-the-hostname-of-a-satellite-host)
+ * [Update Satellite to a new minor version](#update-satellite-to-a-new-minor-version)
 
 ## Cloning a Satellite host
 

--- a/roles/sat6repro/tasks/main.yml
+++ b/roles/sat6repro/tasks/main.yml
@@ -54,8 +54,6 @@
   yum: name=satellite state=latest
   when: satelliteversion == 6.2
 
-- name: "Install rsync on the Ansible Control Node"
-  local_action: yum name=rsync state=latest
 - name: "Install rsync on empty host"
   yum: name=rsync state=latest
 


### PR DESCRIPTION
Reasons:
1. The tasks mentioned in the sat6repro/tasks/main.yml should be focusing only on updating the Satellite host
2. Installing of a task requires that Ansible needs to run as a root user on the Control node which is not a recommended practice.

Fixes #37