### PR TITLE
Removed copy/synchronize tasks from the satellite-clone tool.

### DIFF
--- a/docs/cloning.md
+++ b/docs/cloning.md
@@ -12,16 +12,17 @@
 
   **Note** The ansible playbook run will fail if the free space in root partition is less than the value specified in `required_root_free_space` variable in [roles/sat6repro/vars/main.yml] (roles/sat6repro/vars/main.yml)
 
+2. Place the backup files in a folder on the Destination node. Also remember this folder path, as this needs to be updated in Control node config file (`backup_dir` variable in `roles/sat6repro/vars/main.yml`) later.
+
 #### On the Control node:
 
-1. Move the data backup tar files - config, pgsql, mongodb to the Control Node  under the project folder - [satellite-clone/roles/sat6repro/files] (roles/sat6repro/files) so Ansible can find them.
-2. Create file `roles/sat6repro/vars/main.yml` (by copying `roles/sat6repro/vars/main.sample.yml`) and update it as necessary.
+1. Create file `roles/sat6repro/vars/main.yml` (by copying `roles/sat6repro/vars/main.sample.yml`) and update it as necessary.
 
    ```console
      # cp roles/sat6repro/vars/main.sample.yml roles/sat6repro/vars/main.yml
    ```
+2. Update the folder path of the backup files on the Destination node in `backup_dir` variable in `roles/sat6repro/vars/main.yml`.
 3. Add the IP address of the Destination node to the copied inventory file. If executing the playbook on localhost, add `ansible_connection=local` after the IP address.
-
 4. Run the ansible playbook:
 
     ```console
@@ -33,5 +34,3 @@
   2. To view the sequence of steps performed by this playbook see the [readme] (roles/sat6repro/README.md#sequence-of-steps-performed-by-this-playbook) section of the sat6repro role.
   3. The playbook will reset the admin password to "changeme"
   4. The installer will be run with `--foreman-proxy-dns false --foreman-proxy-dhcp false` to avoid configuration errors during the install. If you want to use provisioning on the cloned Satellite, you will have to manually re-enable these settings.
-
-

--- a/roles/sat6repro/tasks/main.yml
+++ b/roles/sat6repro/tasks/main.yml
@@ -49,29 +49,9 @@
   yum: name=satellite state=latest
   when: satelliteversion == 6.2
 
-- name: "Install rsync on empty host"
-  yum: name=rsync state=latest
-
-# Download backup tar files
-- name: Download backup data - config files
-  copy: src="{{ config_files_tar_file_name }}" dest=/tmp/config_files.tar.gz
-  when: perform_restore
-- name: Download backup data - pgsql
-  copy: src="{{ pgsql_data_tar_file_name }}" dest=/tmp/pgsql_data.tar.gz
-  when: perform_restore
-- name: Download backup data - mongod
-  copy: src="{{ mongo_data_tar_file_name }}" dest=/tmp/mongo_data.tar.gz
-  when: perform_restore
-- name: Download backup data - pulp_data (this may take a long time!)
-  when: perform_restore and include_pulp_data
-  synchronize:
-    src: "{{ pulp_data_tar_file_name }}"
-    dest: /tmp/pulp_data.tar
-    partial: yes
-
 # Run Satellite installer
 - name: untar config files
-  command: tar --selinux --overwrite -xvf /tmp/config_files.tar.gz  -C /
+  command: tar --selinux --overwrite -xvf {{ backup_dir }}/config_files.tar.gz  -C /
   when: perform_restore
 - name: run Satellite 6.1 installer
   command: katello-installer

--- a/roles/sat6repro/tasks/restore.yml
+++ b/roles/sat6repro/tasks/restore.yml
@@ -5,16 +5,16 @@
   service: name=postgresql state=stopped
 
 - name: Restore postgresql data
-  command: tar --selinux --overwrite -xvf /tmp/pgsql_data.tar.gz -C /
+  command: tar --selinux --overwrite -xvf {{ backup_dir }}/pgsql_data.tar.gz -C /
 
 - name: Start postgresql
   service: name=postgresql state=started
 
 - name: Restore mongo data
-  command: tar --selinux --overwrite -xvf /tmp/mongo_data.tar.gz -C /
+  command: tar --selinux --overwrite -xvf {{ backup_dir }}/mongo_data.tar.gz -C /
 
 - name: Restore pulp data (this may take a long time!)
-  command: tar --selinux --overwrite -xvf /tmp/pulp_data.tar -C /
+  command: tar --selinux --overwrite -xvf {{ backup_dir }}/pulp_data.tar -C /
   when: include_pulp_data
 
 - name: Start mongod

--- a/roles/sat6repro/vars/main.sample.yml
+++ b/roles/sat6repro/vars/main.sample.yml
@@ -10,22 +10,33 @@ rhelversion: 7
 # Satellite version.  Use 6.1 or 6.2
 satelliteversion: 6.1
 
-
-# Place the Satellite backup files only in satellite-clone/roles/sat6repro/files folder.
-# NOTE: Just type the file names here and don't include the path names.
+# Restoring of saved backup data is optional.
+# If `perform_restore` is set to true:
+#   - Restore of saved backup data is performed.  Make sure to also udpate `backup_dir` below.
+# If `perform_restore` is set to false:
+#   - This gives you an opportunity to install just Satellite without restoring backup data.
+#   - Warning: This beats the purpose of using the satellite-clone utility, but gives you an opportunity to play with a fresh Satellite install.
 perform_restore: true
-config_files_tar_file_name: config_files.tar.gz
-pgsql_data_tar_file_name: pgsql_data.tar.gz
-mongo_data_tar_file_name: mongo_data.tar.gz
 
-# Restoring a pulp_data.tar file from a backup is optional. Change include_pulp_data to false to skip.
-# If you skip this step, repositories will still be set up, but will be unsynced.
-# Any manually uploaded content will have to be re-uploaded.
-include_pulp_data: false
-pulp_data_tar_file_name: pulp_data.tar
+# The backup folder on your Destination node.
+# NOTE: Place the backup files only on the Destination node and not on the Ansible Control node.
+# WARNING:
+#    1. The backup files *must* be named exactly as mentioned below. If the file names don't match, the script will stop with an error.
+#       a. config_files.tar.gz
+#       b. pgsql_data.tar.gz
+#       c. mongo_data.tar.gz
+#    2. If the folder mentioned by `backup_dir` does not exist or not accessible, the script will stop with an error.
+backup_dir: /backup
 
+# Restoring a pulp_data.tar file from a backup is optional.
+# If `include_pulp_data` is set to false:
+#   - repositories will still be set up, but will be unsynced.
+#   - Any manually uploaded content will have to be re-uploaded.
+# If `include_pulp_data` is set to true:
+#   - you must have `pulp_data.tar` file in the path specified `backup_dir` variable. Otherwise, the script will stop with an error.
+include_pulp_data: true
 
-# Registration info - Credentials to register your host to RH portal
+# Registration info - Credentials to register your host to RH portal.
 activationkey: changeme
 org: 111111
 
@@ -33,7 +44,7 @@ org: 111111
 # This defines the minimum free GBs that should be present in your root partition. Update this in accordance with the data present in your Satellite.
 required_root_free_space: 75
 
-# Disable firewall - This setting can optionally be used to disable firewall to setup Satellite for testing purposes
+# Disable firewall - This setting can optionally be used to disable firewall to setup Satellite for testing purposes.
 disable_firewall: false
 
 # Run katello-reindex - This setting can optionally be used to run katello reindex after the Satellite install.


### PR DESCRIPTION
Why?
The copy or synchronize Ansible modules are unreliable while transfering large files and we see errors often in these scenarios.  Alternatively, the user has to push the backup files on the Destination node manually.

Fixes #60