### PR TITLE
[WIP] Adds mass re-sync of repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ideally, you need two hosts to run this project:
   ```console
      # git clone https://github.com/RedHatSatellite/satellite-clone.git
   ```
-3. Create an inventory file named `inventory` (by copying `inventory.sample`) and update it as necessary:
+3. Create an inventory file named `inventory` (by copying `inventory.sample`) and update it with the Destination node's IP address:
 
   ```console
     # cp inventory.sample inventory
@@ -47,3 +47,4 @@ Now you can proceed to any of the following tasks:
  * [Cloning a Satellite host](docs/cloning.md)
  * [Changing the hostname of a Satellite host](docs/hostname-change.md)
  * [Update Satellite to a new minor version](docs/minor-update.md)
+ * [Sync all repos on a Satellite](docs/mass-sync.md)

--- a/docs/cloning.md
+++ b/docs/cloning.md
@@ -12,7 +12,7 @@
 
   **Note** The ansible playbook run will fail if the free space in root partition is less than the value specified in `required_root_free_space` variable in [roles/sat6repro/vars/main.yml] (roles/sat6repro/vars/main.yml)
 
-#### On the Control node:
+#### On the Control node
 
 1. Move the data backup tar files - config, pgsql, mongodb to the Control Node  under the project folder - [satellite-clone/roles/sat6repro/files] (roles/sat6repro/files) so Ansible can find them.
 2. Create file `roles/sat6repro/vars/main.yml` (by copying `roles/sat6repro/vars/main.sample.yml`) and update it as necessary.

--- a/docs/mass-sync.md
+++ b/docs/mass-sync.md
@@ -1,0 +1,8 @@
+## Cloning a Satellite host
+
+This playbook will trigger a sync for all repos on your Satellite. This is a helpful playbook to run after cloning without a pulp_data.tar file, which will leave you with unsynced repos.
+
+#### On the Control node
+
+1. Update `roles/mass_repo_resync/vars/main.yml` with your Satellite admin username and password.
+2. Run `ansible-playbook -i inventory satelite-mass-sync-playbook.yml`

--- a/roles/mass_repo_resync/scripts/mass_resync.rb
+++ b/roles/mass_repo_resync/scripts/mass_resync.rb
@@ -1,0 +1,9 @@
+#!/usr/bin/ruby
+username = ARGV[0]
+password = ARGV[1]
+orgs = `hammer -p changeme --csv organization list | tail -n+2 | awk -F, {'print $1'}`
+orgs.split("\n").each do |org|
+  `hammer -p changeme --csv repository list --organization-id #{org} | grep -vi '^ID' | awk -F, {'print $1'}`.split("\n").each do |repo|
+    `hammer -p changeme repository synchronize --id #{repo} --organization-id #{org} --async`
+  end
+end

--- a/roles/mass_repo_resync/tasks/main.yml
+++ b/roles/mass_repo_resync/tasks/main.yml
@@ -1,0 +1,1 @@
+- script: /roles/mass_repo_resync/scripts/mass_resync.rb {{ admin_username }} {{ admin_password }}

--- a/roles/mass_repo_resync/vars/main.yml
+++ b/roles/mass_repo_resync/vars/main.yml
@@ -1,0 +1,5 @@
+# admin username for sat6
+admin_username = "changeme"
+
+# admin password for sat6
+admin_password = "changeme"

--- a/satellite-mass-sync-playbook.yml
+++ b/satellite-mass-sync-playbook.yml
@@ -1,0 +1,4 @@
+- hosts: satellite6
+  remote_user: root
+  roles:
+    - mass-sync


### PR DESCRIPTION
When a user clones a satellite, if they did not include the
pulp_data.tar file, the repos will be left unsynced. This
script can be run to re-sync all repos on the Satellite.