### PR TITLE
Reorder steps to avoid libselinux-python errors

### DIFF
--- a/roles/sat6repro/tasks/main.yml
+++ b/roles/sat6repro/tasks/main.yml
@@ -5,6 +5,14 @@
 - include: pre_install_check.yml
   when: run_pre_install_check
 
+# Register/subscribe the VM
+- name: register host
+  command: subscription-manager register --force --activationkey={{ activationkey }} --org {{ org }}
+- name: disable all repos
+  command: subscription-manager repos --disable "*"
+- name: Enable required repos
+  command: subscription-manager repos --enable rhel-{{ rhelversion }}-server-rpms --enable rhel-server-rhscl-{{ rhelversion }}-rpms --enable rhel-{{ rhelversion }}-server-satellite-{{ satelliteversion }}-rpms
+
 # Install libselinux package
 - name: install libselinux-python for rhel6
   yum: name=libselinux-python state=latest
@@ -28,14 +36,6 @@
   when: ansible_distribution_major_version == "7"
 - name: create /etc/hosts
   template: src=hosts.j2 dest=/etc/hosts
-- name: register host
-
-# Register/subscribe the VM
-  command: subscription-manager register --force --activationkey={{ activationkey }} --org {{ org }}
-- name: disable all repos
-  command: subscription-manager repos --disable "*"
-- name: Enable required repos
-  command: subscription-manager repos --enable rhel-{{ rhelversion }}-server-rpms --enable rhel-server-rhscl-{{ rhelversion }}-rpms --enable rhel-{{ rhelversion }}-server-satellite-{{ satelliteversion }}-rpms
 
 # Install vim for easy editing of config files later
 - name: Install vim


### PR DESCRIPTION
tested up to this step to make sure it worked
 ```

TASK [sat6repro : register host] ***********************************************
changed: [192.168.121.78]

TASK [sat6repro : disable all repos] *******************************************
changed: [192.168.121.78]

TASK [sat6repro : Enable required repos] ***************************************
changed: [192.168.121.78]

TASK [sat6repro : install libselinux-python for rhel6] *************************
dchanged: [192.168.121.78]

TASK [sat6repro : turn off firewalld - rhel7] **********************************
skipping: [192.168.121.78]

TASK [sat6repro : turn off firewall - rhel6] ***********************************
skipping: [192.168.121.78] => (item=service iptables stop) 
skipping: [192.168.121.78] => (item=chkconfig iptables off) 

TASK [sat6repro : set host_name] ***********************************************
changed: [192.168.121.78]

TASK [sat6repro : check /etc/hostname] *****************************************
skipping: [192.168.121.78]

TASK [sat6repro : create /etc/hosts] *******************************************
changed: [192.168.121.78]

TASK [sat6repro : Install vim] *************************************************
changed: [192.168.121.78]

TASK [sat6repro : Install Satellite 6.1 packages] ******************************
skipping: [192.168.121.78]

TASK [sat6repro : Install Satellite 6.2 packages] ******************************
```