### PR TITLE
Skipping untaring /var/lib/pulp/katello-export

### DIFF
--- a/roles/sat6repro/tasks/restore.yml
+++ b/roles/sat6repro/tasks/restore.yml
@@ -14,7 +14,7 @@
   command: tar --selinux --overwrite -xvf {{ backup_dir }}/mongo_data.tar.gz -C /
 
 - name: Restore pulp data (this may take a long time!)
-  command: tar --selinux --overwrite -xvf {{ backup_dir }}/pulp_data.tar -C /
+  command: tar --selinux --overwrite -xvf {{ backup_dir }}/pulp_data.tar --exclude=var/lib/pulp/katello-export -C /
   when: include_pulp_data
 
 - name: Start mongod


### PR DESCRIPTION
- This is not really needed in pulp as this is part of inter satellite sync

Fixes #81