### PR TITLE
Update README.md for control_node_setup script link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Ideally, you need two hosts to run this project:
    ```console
      # git clone https://github.com/RedHatSatellite/satellite-clone.git
    ```
-   NOTE: Optionally you may utilize the script [control_node_setup.sh] (../helpers/control_node_setup.sh) to perform step 2 below.  The instructions to use this script are documented in the script itself.
+   NOTE: Optionally you may utilize the script [control_node_setup.sh] (../master/helpers/control_node_setup.sh) to perform step 2 below.  The instructions to use this script are documented in the script itself.
 2. Install `ansible` package on the Control node. For RHEL boxes, [access to EPEL] (https://access.redhat.com/solutions/3358) is required.
 
    ```console


### PR DESCRIPTION
I was going through the documentation and found that link seems to be broken to setup control node. I've updated the link for the script. Thanks