### PR TITLE
Derive the hostname from the backup config files.

### DIFF
--- a/docs/cloning.md
+++ b/docs/cloning.md
@@ -2,6 +2,7 @@
 
  **Important Notes:**
 
+  - The playbook will update the cloned Satellite hostname to match the hostname of the original Satellite from which the backup is generated.
   - DHCP, DNS, and TFTP will be disabled during the install to avoid configuration errors. If you want to use provisioning on the cloned Satellite, you will have to manually re-enable these settings.
   - The playbook will reset the admin password to "changeme".
   - The playbook installs Satellite and may may take a while to complete.

--- a/roles/sat6repro/tasks/main.yml
+++ b/roles/sat6repro/tasks/main.yml
@@ -1,6 +1,17 @@
 ---
 - include_vars: main.yml
 
+# Identify hostname from backup config file
+- name: Identify the hostname from the backup config tar file
+  shell: tar zxf {{ backup_dir }}/config_files.tar.gz etc/foreman-proxy/settings.yml --to-stdout | grep foreman_url |sed 's#.*/##'
+  register: backup_hostname_result
+- name: Check that the hostname is not none
+  fail: msg="Unable to derive Satellite hostname from the backup config file - value ({{ backup_hostname_result.stdout }}) doesn't look right"
+  when: backup_hostname_result.stderr
+- name: set hostname
+  set_fact:
+    hostname: "{{ backup_hostname_result.stdout }}"
+
 # include pre_install_check
 - include: pre_install_check.yml
   when: run_pre_install_check

--- a/roles/sat6repro/vars/main.sample.yml
+++ b/roles/sat6repro/vars/main.sample.yml
@@ -3,8 +3,6 @@
 
 # Satellite host info
 
-# NOTE: Provide the *backed up* Satellite hostname fqdn only.  Using any other hostname will result in installation error.
-hostname: satellite.example.com
 # Satellite version.  Use 6.1 or 6.2
 satelliteversion: 6.1
 


### PR DESCRIPTION
- This makes the config even easier since the user doesn't need to fetch this manually.

Fixes #21