### PR TITLE
Remove `perform_restore` option from configs.

### DIFF
--- a/roles/sat6repro/tasks/main.yml
+++ b/roles/sat6repro/tasks/main.yml
@@ -63,7 +63,6 @@
 # Run Satellite installer
 - name: untar config files
   command: tar --selinux --overwrite -xvf {{ backup_dir }}/config_files.tar.gz  -C /
-  when: perform_restore
 - name: run Satellite 6.1 installer
   command: katello-installer --capsule-dns false --capsule-dhcp false --capsule-tftp false
   when: satelliteversion == 6.1
@@ -73,7 +72,6 @@
 
 # restore backup data
 - include: restore.yml
-  when: perform_restore
 
 - name: Restart katello-service
   command: katello-service start

--- a/roles/sat6repro/tasks/pre_install_check.yml
+++ b/roles/sat6repro/tasks/pre_install_check.yml
@@ -21,10 +21,9 @@
     get_checksum: False
     get_md5: False
   register: config_result
-  when: perform_restore
 - name: Fail if the config tar file is not present or not accessible
   fail: msg="{{ backup_dir }}/config_files.tar.gz is not present or not accessible"
-  when: perform_restore and not config_result.stat.exists
+  when: not config_result.stat.exists
 
 - name: Check the presence of mongo tar file
   stat:
@@ -32,10 +31,9 @@
     get_checksum: False
     get_md5: False
   register: mongo_result
-  when: perform_restore
 - name: Fail if the mongo tar file is not present or not accessible
   fail: msg="{{ backup_dir }}/mongo_data.tar.gz is not present or not accessible"
-  when: perform_restore and not mongo_result.stat.exists
+  when: not mongo_result.stat.exists
 
 - name: Check the presence of pgsql tar file
   stat:
@@ -43,10 +41,9 @@
     get_checksum: False
     get_md5: False
   register: pgsql_result
-  when: perform_restore
 - name: Fail if the pgsql tar file is not present or not accessible
   fail: msg="{{ backup_dir }}/pgsql_data.tar.gz is not present or not accessible"
-  when: perform_restore and not pgsql_result.stat.exists
+  when: not pgsql_result.stat.exists
 
 - name: Check the presence of pulp tar file
   stat:
@@ -54,7 +51,7 @@
     get_checksum: False
     get_md5: False
   register: pulp_result
-  when: perform_restore and include_pulp_data
+  when: include_pulp_data
 - name: Fail if the pulp tar file is not present or not accessible
   fail: msg="{{ backup_dir }}/pulp_data.tar is not present or not accessible"
-  when: perform_restore and include_pulp_data and not pulp_result.stat.exists
+  when: include_pulp_data and not pulp_result.stat.exists

--- a/roles/sat6repro/vars/main.sample.yml
+++ b/roles/sat6repro/vars/main.sample.yml
@@ -10,14 +10,6 @@ rhelversion: 7
 # Satellite version.  Use 6.1 or 6.2
 satelliteversion: 6.1
 
-# Restoring of saved backup data is optional.
-# If `perform_restore` is set to true:
-#   - Restore of saved backup data is performed.  Make sure to also udpate `backup_dir` below.
-# If `perform_restore` is set to false:
-#   - This gives you an opportunity to install just Satellite without restoring backup data.
-#   - Warning: This beats the purpose of using the satellite-clone utility, but gives you an opportunity to play with a fresh Satellite install.
-perform_restore: true
-
 # The backup folder on your Destination node.
 # NOTE: Place the backup files only on the Destination node and not on the Ansible Control node.
 # WARNING:


### PR DESCRIPTION
The satellite-clone playbook was also used to quickly install a sat 6.1 or sat 6.2 box without actually restoring backup data. But this beats the purpose of this playbook and this playbook should stay simple and support just cloning. So perform_restore option will be removed.  A new playbook needs to be created in future if there is an intent to support plain install of Satellite without backup data.

Fixes #97