### PR TITLE
Satellite 6.1 doesn't stop postgresql while stopping katello-service

### DIFF
--- a/roles/satellite-clone/tasks/restore.yml
+++ b/roles/satellite-clone/tasks/restore.yml
@@ -1,6 +1,10 @@
 - name: Stop katello services
   command: katello-service stop
 
+# Satellite 6.1 doesn't stop postgresql with katello-service stop
+- name: Stop postgresql
+  service: name=postgresql state=stopped
+
 - name: Restore postgresql data
   command: tar --selinux --overwrite -xvf {{ backup_dir }}/pgsql_data.tar.gz -C /
   when: not rhel_migration


### PR DESCRIPTION
Fix: force stopping postgresql

I am enabling this task for both 6.1 and 6.2 to make sure that postgresql is indeed stopped while restoring postgresql data.