### PR TITLE
Disassociate capsules with lifecycle environments

### DIFF
--- a/docs/satellite-clone.md
+++ b/docs/satellite-clone.md
@@ -9,6 +9,7 @@
   - You can clone RHEL 6 backup data to a RHEL 7 machine.  In this case, you must update the variable `rhel_migration` to true as explained later in this document. Please note that this scenario is supported only for *Satellite 6.2*.
   - If you are using NFS for storage and your pulp backup tar file is large (>150 gb), you might see memory errors while untaring pulp data.  In this case you can optionally choose to skip pulp restore (by setting `include_pulp_data` to `false` in `satellite-clone-vars.yml`).
   - After running the playbook, existing manifests may have to be refreshed.
+  - Capsules will be unassociated with Lifecycle environments to avoid any interference with existing infrastructure. Instructions to reverse these changes can be found in `logs/reassociate_capsules.txt` under Satellite Clone's root directory
 
 #### Prerequisites ####
 

--- a/roles/satellite-clone/files/disassociate_capsules.rb
+++ b/roles/satellite-clone/files/disassociate_capsules.rb
@@ -1,0 +1,27 @@
+#!/usr/bin/ruby
+username = "admin"
+password = "changeme"
+external_capsules = []
+external_capsule_ids = `hammer -u #{username} -p #{password} --csv capsule list --search 'feature = \"Pulp Node\"' | tail -n+2 | awk -F, {'print $1'}`
+external_capsule_ids.split("\n").each do |id|
+  lifecycle_environment = `hammer -u #{username} -p #{password} --csv capsule content lifecycle-environments --id #{id} | tail -n+2 | awk -F, {'print $2'}`.split("\n")
+  name = `hammer -u #{username} -p #{password} --csv capsule info --id #{id} | tail -n+2 | awk -F, {'print $2'}`.chomp
+  organization = `hammer -u #{username} -p #{password} --csv capsule info --id 2 | tail -n+2 | awk -F, '{print $(NF-2)}'`.chomp
+  external_capsules << {:id => id, :name => name, :lifecycle_environments => lifecycle_environment, :organization => organization}
+end
+
+reverse_commands = []
+external_capsules.each do |capsule|
+  capsule[:lifecycle_environments].each do |env|
+    `hammer -u #{username} -p #{password} --csv capsule content remove-lifecycle-environment --id #{capsule[:id]} --environment #{env} --organization "#{capsule[:organization]}"`
+    reverse_command = "hammer -u #{username} -p #{password} --csv capsule content add-lifecycle-environment --id #{capsule[:id]} --environment #{env} --organization \"#{capsule[:organization]}\""
+    reverse_commands << reverse_command
+  end
+end
+
+STDOUT.puts "All Capsules are unassociated with any lifecycle environments. This is to avoid any syncing errors with your original Satellite " \
+            "and any interference with existing infrastructure. To reverse these changes, run the following commands," \
+            " making sure to replace the credentials with your own."
+reverse_commands.each do |reverse|
+  STDOUT.puts reverse
+end

--- a/roles/satellite-clone/tasks/main.yml
+++ b/roles/satellite-clone/tasks/main.yml
@@ -147,6 +147,13 @@
   command: satellite-installer --upgrade
   when: rhel_migration
 
+- name: Disassociate capsules with lifecycle environments (to avoid the cloned Satellite server talking with live capsules)
+  script: disassociate_capsules.rb
+  register: disassociate_capsules
+
+- name: copy disassociate_capsules.rb output
+  local_action: copy content={{ disassociate_capsules.stdout }} dest={{ playbook_dir }}/logs/reassociate_capsules.txt
+
 - debug:
     msg: "****NOTE**** Your Satellite's hostname is updated to match the original Satellite
           ****NOTE**** Your Satellite's password is updated to changeme"


### PR DESCRIPTION
Fixes #134
The cloned satellite will still try to communicate with existing capsules,
so we can disassociate them to avoid any connection issues and interference
with exisiting setup. When the user has configured the capsules properly,
there will be instructions on how to reassociate the capsules.