### PR TITLE
don't check password is changeme on hostname change

### DIFF
--- a/roles/satellite-hostname/tasks/main.yml
+++ b/roles/satellite-hostname/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: "check that variables are updated"
   fail: msg="Please update the variables in satellite-hostname-vars.yml"
-  when: (new_hostname == "changeme.example.com") or (admin_username == "changeme") or (admin_password == "changeme")
+  when: (new_hostname == "changeme.example.com") or (admin_username == "changeme")
 
 # need to change from my fork when https://github.com/Katello/katello-packaging/pull/323/files is merged
 - name: download katello-change-hostname script


### PR DESCRIPTION
Our default password is "changeme" in dev environments and after a clone, so this check fails quite a bit. Just checking the new_hostname and admin_username have changes is enough to tell if the user has edited the file.

We should probably refine this check a bit more, but this will unblock automation for now