### PR TITLE
Don't enable or disable repos when register to portal is false.

### DIFF
--- a/roles/satellite-clone/tasks/main.yml
+++ b/roles/satellite-clone/tasks/main.yml
@@ -41,8 +41,10 @@
   when: register_to_portal
 - name: disable all repos
   command: subscription-manager repos --disable "*"
+  when: register_to_portal
 - name: Enable required repos
   command: subscription-manager repos --enable rhel-{{ ansible_distribution_major_version }}-server-rpms --enable rhel-server-rhscl-{{ ansible_distribution_major_version }}-rpms --enable rhel-{{ ansible_distribution_major_version }}-server-satellite-{{ satellite_version }}-rpms
+  when: register_to_portal
 
 # Install libselinux package
 - name: Ensure libselinux-python package is present (required by ansible)


### PR DESCRIPTION
If the user is disabling "register to portal", it means they have
already enabled the necessary repos and we shouldn't do anything
with subscriptions.