### PR TITLE
Ansible is not available in EPEL, changed it to RHEL7 extras repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Satellite-clone contains simple Ansible playbooks that can be used to setup a Sa
      # git clone https://github.com/RedHatSatellite/satellite-clone.git
    ```
 
-2. Install `ansible` package on the server.  Ansible should be installed from epel.
+2. Install `ansible` package on the server.  Ansible should be installed from extras channel.
    ```console
-     # yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+     # subscription-manager repos --enable rhel-7-server-extras-rpms
      # yum install -y ansible
    ```
 


### PR DESCRIPTION
Hi,

Currently the ansible package is not available from EPEL so rather use rhel-7-server-extras-rpms repository.

[root@~]# yum repolist
Loaded plugins: product-id, search-disabled-repos, subscription-manager
This system is registered with an entitlement server, but is not receiving updates. You can use subscription-manager to assign subscriptions.
repo id                                                                              repo name                                                                                                               status
epel/x86_64                                                                          Extra Packages for Enterprise Linux 7 - x86_64                                                                          12,005
repolist: 12,005


# yum search ansible
Loaded plugins: product-id, search-disabled-repos, subscription-manager
This system is registered with an entitlement server, but is not receiving updates. You can use subscription-manager to assign subscriptions.
============================================================================================== N/S matched: ansible ===============================================================================================
ansible-inventory-grapher.noarch : Creates graphs representing ansible inventory
ansible-lint.noarch : Best practices checker for Ansible
ansible-openstack-modules.noarch : Unofficial Ansible modules for managing Openstack
ansible-review.noarch : Reviews Ansible playbooks, roles and inventory and suggests improvements
python2-ansible-tower-cli.noarch : A CLI tool for Ansible Tower
kubernetes-ansible.noarch : Playbook and set of roles for seting up a Kubernetes cluster onto machines
loopabull.noarch : Event loop driven Ansible playbook execution engine

