### PR TITLE
Fixes pulp duplicate key error

### DIFF
--- a/roles/satellite-clone/tasks/reset_pulp_data.yml
+++ b/roles/satellite-clone/tasks/reset_pulp_data.yml
@@ -11,3 +11,6 @@
 - name: reset pulp data in 6.1
   command: echo "Katello::Erratum.all.destroy_all" | foreman-rake console
   when: satellite_version == 6.1
+
+- name: migrate pulp db
+  command: sudo -u apache pulp-manage-db


### PR DESCRIPTION
Fixes #255
When cloning w/o pulp_data.tar, the database has to be migrated
to recreate indexes and prevent errors like duplicate key errors.