### PR TITLE
Actually drop mongodb

### DIFF
--- a/roles/satellite-clone/tasks/reset_pulp_data.yml
+++ b/roles/satellite-clone/tasks/reset_pulp_data.yml
@@ -2,7 +2,7 @@
   command: mongo pulp_database --eval "db.units_distribution.drop();db.units_docker_blob.drop();db.units_docker_image.drop();db.units_docker_manifest.drop();db.units_docker_tag.drop();db.units_drpm.drop();db.units_erratum.drop();db.units_iso.drop();db.units_package_category.drop();db.units_package_environment.drop();db.units_package_group.drop();db.units_puppet_module.drop();db.units_rpm.drop();db.units_srpm.drop();db.units_yum_repo_metadata_file.drop();db.repo_content_units.drop();"
 
 - name: reset pulp repo importers
-  command: 'echo "db.repo_importers.update({}, {\$set: {\"scratchpad.repomd_revision\": null}}, {multi: true});" | mongo pulp_database'
+  command: 'mongo pulp_database --eval "db.repo_importers.update({\"scratchpad.repomd_revision\": {$exists: true}}, {$set: {\"scratchpad.repomd_revision\": null}}, {multi: true});"'
 
 - name: reset pulp data in 6.2
   command: echo "Katello::Rpm.all.destroy_all; Katello::Erratum.all.destroy_all; Katello::PackageGroup.all.destroy_all; Katello::PuppetModule.all.destroy_all; Katello::DockerManifest.all.destroy_all; Katello::DockerTag.all.destroy_all" | foreman-rake console

--- a/roles/satellite-clone/tasks/restore_mongo_dump.yml
+++ b/roles/satellite-clone/tasks/restore_mongo_dump.yml
@@ -1,5 +1,5 @@
 - name: Drop old mongo database
-  command: echo 'db.dropDatabase();' | mongo pulp_database
+  command: mongo pulp_database --eval "db.dropDatabase()"
 
 - name: Restore new mongo data
   command: mongorestore --host localhost {{ backup_dir }}/mongo_dump/pulp_database/


### PR DESCRIPTION
The echo command we were using wasn't actually dropping the mongo
database, but rather echoing 'db.dropDatabase();' | mongo pulp_database

This resulted in data being restored on an existing database.

So the mongo database stayed during restore. We didn't notice many issues
because not much is in the mongo database on a clean satellite install.

Fixes #259