### PR TITLE
Fixes #268 - disable IPA authentication

### DIFF
--- a/roles/satellite-clone/tasks/main.yml
+++ b/roles/satellite-clone/tasks/main.yml
@@ -163,7 +163,7 @@
   command: katello-installer --capsule-dns false --capsule-dhcp false --capsule-tftp false
   when: satellite_version == 6.1
 - name: run Satellite 6.2 installer
-  command: satellite-installer --scenario satellite --foreman-proxy-dns false --foreman-proxy-dhcp false --foreman-proxy-tftp false --no-enable-foreman-plugin-remote-execution --no-enable-foreman-proxy-plugin-remote-execution-ssh
+  command: satellite-installer --scenario satellite --foreman-proxy-dns false --foreman-proxy-dhcp false --foreman-proxy-tftp false --no-enable-foreman-plugin-remote-execution --no-enable-foreman-proxy-plugin-remote-execution-ssh --foreman-ipa-authentication false
   when: satellite_version == 6.2
 
 - block:


### PR DESCRIPTION
Added --foreman-ipa-authentication false for installer for the situations where old server had OS level IPA auth configured and it is missing on the new server.