### PR TITLE
Add option to not overwrite /etc/hosts

### DIFF
--- a/roles/satellite-clone/defaults/main.yml
+++ b/roles/satellite-clone/defaults/main.yml
@@ -12,3 +12,4 @@ rhel_migration: False
 disable_postgres_triggers: True
 restorecon: False
 skip_satellite_rpm_check: False
+overwrite_etc_hosts: True

--- a/roles/satellite-clone/tasks/main.yml
+++ b/roles/satellite-clone/tasks/main.yml
@@ -86,8 +86,10 @@
 - name: check /etc/hostname
   lineinfile: dest=/etc/hostname line={{ hostname }}
   when: ansible_distribution_major_version == "7"
+
 - name: create /etc/hosts
   template: src=hosts.j2 dest=/etc/hosts
+  when: overwrite_etc_hosts
 
 # Install Satellite packages
 - name: Install Satellite 6.1 packages

--- a/satellite-clone-vars.sample.yml
+++ b/satellite-clone-vars.sample.yml
@@ -70,3 +70,8 @@ org: changeme
 #
 # Skip checking that satellite isn't already installed. (defaults to false)
 #skip_satellite_rpm_check: false
+#
+# Overwrite /etc/hosts file. The playbook will overwrite /etc/hosts file with the hostname from the backup files provided. If you
+# have a custom /etc/hosts file and do not want it overwritten, you can disable this step and setup the file yourself. If you
+# do disable this option, make sure the original Satellite's hostname can resolve to 127.0.0.1 (defaults to true)
+#overwrite_etc_hosts: true


### PR DESCRIPTION
Some users have custom /etc/hosts files
to resolve to the cdn or similar, they can
use this option to custom configure their
/etc/hosts before running the clone.

Fixes #281