### PR TITLE
Made portal registration disabled by default.

### DIFF
--- a/roles/satellite-clone/defaults/main.yml
+++ b/roles/satellite-clone/defaults/main.yml
@@ -7,7 +7,7 @@ required_root_free_space: 75
 disable_firewall: False
 run_katello_reindex: False
 run_pre_install_check: True
-register_to_portal: True
+register_to_portal: False
 rhel_migration: False
 disable_postgres_triggers: True
 restorecon: False

--- a/roles/satellite-clone/tasks/main.yml
+++ b/roles/satellite-clone/tasks/main.yml
@@ -41,11 +41,11 @@
   fail: msg="Unable to derive Satellite hostname from the backup config file - value ({{ hostname }}) doesn't look right"
   when: backup_hostname.stderr
 
-- name: Check that mandatory variables are updated
+- name: Check that the registration variables (activationkey, org) are updated
   fail: msg="Please update the variables in /etc/satellite-clone/satellite-clone-vars.yml"
   when: ((activationkey == "changeme") or (org == "changeme")) and register_to_portal
 
-# Register/subscribe the VM
+# Register/subscribe the VM to Red Hat Portal
 - name: register host
   command: "subscription-manager register --force --activationkey='{{ activationkey }}' --org '{{ org }}'"
   when: register_to_portal

--- a/satellite-clone-vars.sample.yml
+++ b/satellite-clone-vars.sample.yml
@@ -1,22 +1,4 @@
 ---
-############## required variables ####################
-# Registration info - Credentials to register your Satellite to Red Hat portal
-# - You will need an activation key with a Satellite subscription.
-# - For security reasons only Activationkey / Org combination is supported for now.
-# - If you don't know how to create Activation keys in https://access.redhat.com, refer
-#   to the knowledge base article https://access.redhat.com/articles/1378093.  In this
-#   document, there are separate sections for `Creating an Activation Key` and `Finding
-#   your Organization ID`.
-# - If you want to register your Destination node to the portal by yourself, you can
-#   do that and skip the registration part in the playbook run by setting `register_to_portal`
-#   to false in this config.
-# - `org` field below is the unique Red Hat ID for your organization in portal. It may
-#   look like `1111111`.
-activationkey: changeme
-org: changeme
-
-
-
 ############## optional variables ####################
 #
 # The backup folder on your Destination node.
@@ -51,11 +33,25 @@ org: changeme
 # uncomment the following line to override this option (defaults to true)
 #run_pre_install_check: true
 
-# If register_to_portal is set to false:
+# Use register_to_portal to automatically register to Red Hat Portal. By default,
 #   - the host will not be registered to RH portal.
-#   - it is the responsibility of the user to make the required repos available.  Otherwise, the script will stop with an error.
-# uncomment the following line to override this option (defaults to true)
-#register_to_portal: true
+#   - it is the responsibility of the user to make the required repos available.
+# uncomment the following line to override this option (defaults to false). If you override this option, you must update
+# `activationkey` and `org` variables in the next section.
+#register_to_portal: false
+
+# Red Hat Portal Registration info - Credentials to register your Satellite to Red Hat portal
+# - Use this section if and only if `register_to_portal` is `true`.
+# - You will need an activation key with a Satellite subscription.
+# - For security reasons only Activationkey / Org combination is supported for now.
+# - If you don't know how to create Activation keys in https://access.redhat.com, refer
+#   to the knowledge base article https://access.redhat.com/articles/1378093.  In this
+#   document, there are separate sections for `Creating an Activation Key` and `Finding
+#   your Organization ID`.
+# - `org` field below is the unique Red Hat ID for your organization in portal. It may
+#   look like `1111111`.
+#activationkey: changeme
+#org: changeme
 
 # Set this to true if you want to clone a rhel6 Satellite server to a rhel7 machine (defaults to false)
 #rhel_migration: false


### PR DESCRIPTION
By default,
- the server will not be registered to Red Hat Portal
- It is the responsibility of the user to provide right repos for
satellite installation.

Override this setting to `yes` and update `activationkey` and `org`
variables to do the portal regisration automatically.

Fixes #285