### PR TITLE
Disabled Ansible retry option.

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -7,3 +7,4 @@ gathering = smart
 fact_caching = jsonfile
 fact_caching_connection = $PWD/cache
 fact_caching_timeout = 259200
+retry_files_enabled = False


### PR DESCRIPTION
- Ansible retry option is mainly for running the tasks on multiple
machines.  This is not currently applicable for satellite-clone.