### PR TITLE
Updated satellite rpm check

### DIFF
--- a/roles/satellite-clone/defaults/main.yml
+++ b/roles/satellite-clone/defaults/main.yml
@@ -11,5 +11,5 @@ enable_repos: True
 rhel_migration: False
 disable_postgres_triggers: True
 restorecon: False
-skip_satellite_rpm_check: False
+disable_satellite_rpm_check: False
 overwrite_etc_hosts: True

--- a/roles/satellite-clone/tasks/pre_install_check.yml
+++ b/roles/satellite-clone/tasks/pre_install_check.yml
@@ -9,14 +9,14 @@
   register: satellite_rpm
   ignore_errors: yes
   when:
-    - not skip_satellite_rpm_check
+    - not disable_satellite_rpm_check
     - clone_satellite_installed_check is not defined
 
 - name: Fail if satellite is already installed
   fail:
     msg: "Satellite is already installed. Satellite-clone should be run on a clean RHEL7 machine. If you would like to force a skip of this check, please set skip_satellite_rpm_check to true in satellite-clone-vars.yml"
   when:
-    - not skip_satellite_rpm_check
+    - not disable_satellite_rpm_check
     - clone_satellite_installed_check is not defined
     - satellite_rpm.rc | int == 0
 

--- a/satellite-clone-vars.sample.yml
+++ b/satellite-clone-vars.sample.yml
@@ -65,7 +65,9 @@
 #restorecon: false
 
 # Disable checking that satellite is already installed. (defaults to false)
-#skip_satellite_rpm_check: false
+# Once the playbook confirms that there is no satellite installation, the subsequent runs will not run this task.
+# To force run this task for a specific run, use `--flush-cache` option
+#disable_satellite_rpm_check: false
 
 # Overwrite /etc/hosts file (defaults to true). The playbook will overwrite /etc/hosts file with the hostname from the backup files provided. If you
 # have a custom /etc/hosts file and do not want it overwritten, you can disable this step and setup the file yourself. If you


### PR DESCRIPTION
- Renamed the variable `skip_satellite_rpm_check` to `disable_satellite_rpm_check` to make it consistent with other variables.
- Added documentation in satellite-clone-vars.sample file about the clearing cache option to force run this task.