### PR TITLE
Add 6.3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Satellite-clone
 
-Easily setup a Satellite 6.1 or 6.2 server with restored backup data.
+Easily setup a Satellite 6.1, 6.2, or 6.3 server with restored backup data.
 
 ## Getting Started
 Throughout this documentation, ensure that you understand the following terminology:
@@ -9,7 +9,7 @@ Throughout this documentation, ensure that you understand the following terminol
 
 #### What you need: ####
   - A blank (vanilla install) RHEL 7 server (target server). You will run the setup commands here.
-  - A backup from a 6.1 or 6.2 Satellite server (source server) created with `katello-backup`. This backup can be with or without pulp-data, and can be from a RHEL 6 or 7 machine.
+  - A backup from a 6.1, 6.2, or 6.3 Satellite server (source server) created with `katello-backup`. This backup can be with or without pulp-data, and can be from a RHEL 6 or 7 machine.
   - You will need a Satellite 6 subscription for the cloned machine. There are [options](https://access.redhat.com/articles/513353) for obtaining subscriptions at a discounted rate for smaller environments.
 
 #### Setup ####

--- a/docs/satellite-clone.md
+++ b/docs/satellite-clone.md
@@ -58,6 +58,7 @@ This workflow will help transition your environment from a current working Satel
    Required backup files:
    - Standard backup scenario: config_files.tar.gz, mongo_data.tar.gz, pgsql_data.tar.gz, (optional) pulp_data.tar
    - Online backup or RHEL 6 to 7 migration scenario: config_files.tar.gz, mongo_dump folder, foreman.dump, candlepin.dump, (optional) pulp_data.tar
+   - For Satellite 6.3+ backups, you will need the metadata.yml file from the backup as well as the other required files.
 
 2. The target server must have capacity to store the backup files, which the source server transfers to the target server, and the backup files when they are restored.
 

--- a/library/check_metadata_for_satellite_version.py
+++ b/library/check_metadata_for_satellite_version.py
@@ -1,0 +1,50 @@
+import yaml
+import re
+from ansible.module_utils.basic import *
+
+
+# module: check_metadata_for_satellite_version
+# description:
+#    - Return the Satellite version specified in a Satellite backup
+# notes:
+#    - The Satellite version is determined from the Satellite rpm
+#      version using the backup's rpm list from metadata.yml
+# options:
+#    metadata_path:
+#        description:
+#          - Full path (including file name) to metadata.yml
+#        required: true
+def get_satellite_backup_version(params):
+    with open(params["metadata_path"]) as data_file:
+        data = yaml.load(data_file)
+
+    rpms = data[":rpms"]
+    pattern = re.compile("^satellite-[\d+].*")
+    satellite = [r for r in rpms if pattern.match(r)][0]
+    satellite_version = satellite.split("-")[1]
+
+    found_version = '.'.join(satellite_version.split('.')[0:2])
+
+    if found_version not in ["6.2", "6.3"]:
+        return False, dict(msg="Satellite Version is not supported")
+
+    msg = "{0} backup found".format(found_version)
+    result = dict(satellite_version=found_version, msg=msg, changed=False)
+    return True, result
+
+
+def main():
+    fields = {
+        "metadata_path": {"required": True, "type": "str"}
+    }
+
+    module = AnsibleModule(argument_spec=fields)
+    success, result = get_satellite_backup_version(module.params)
+    if success:
+        module.exit_json(**result)
+    else:
+        module.fail_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/satellite-clone/files/disassociate_capsules.rb
+++ b/roles/satellite-clone/files/disassociate_capsules.rb
@@ -2,7 +2,7 @@
 username = "admin"
 password = "changeme"
 external_capsules = []
-external_capsule_ids = `hammer -u #{username} -p #{password} --csv capsule list --search 'feature = \"Pulp Node\"' | tail -n+2 | awk -F, {'print $1'}`
+external_capsule_ids = `hammer -u #{username} -p #{password} --csv capsule list --search 'feature = \"Pulp Node\"' | grep -v "Warning:" | tail -n+2 | awk -F, {'print $1'}`
 if external_capsule_ids.empty?
   STDOUT.puts "There are no external capsules to disassociate."
 else

--- a/roles/satellite-clone/tasks/backup_check.yml
+++ b/roles/satellite-clone/tasks/backup_check.yml
@@ -82,6 +82,18 @@
     clone_mongo_dump_exists: "{{ mongo_dump.stat.exists }}"
     cacheable: True
 
+- name: Check for metadata.yml file
+  stat:
+    path: "{{ backup_dir }}/metadata.yml"
+    get_checksum: False
+    get_md5: False
+  register: metadata
+
+- name: set fact - metadata
+  set_fact:
+    clone_metadata_exists: "{{ metadata.stat.exists }}"
+    cacheable: True
+
 - name: Fail if the config tar file is not present or not accessible
   fail: msg="{{ backup_dir }}/config_files.tar.gz is not present or not accessible"
   when: not clone_config_data_exists

--- a/roles/satellite-clone/tasks/backup_satellite_version_check.yml
+++ b/roles/satellite-clone/tasks/backup_satellite_version_check.yml
@@ -1,0 +1,37 @@
+- name: check for satellite answers file
+  command: tar zxf {{ backup_dir }}/config_files.tar.gz  etc/foreman-installer/scenarios.d/satellite-answers.yaml --to-stdout
+  register: satellite_answers
+  ignore_errors: true
+  no_log: true
+
+- name: setting fact - satellite_answers
+  set_fact:
+    clone_satellite_answers: "{{ (satellite_answers.rc | int) == 0 }}"
+    cacheable: true
+
+- name: Temporarily set satellite_version to 6.2 if satellite_answers.yaml exists
+  set_fact:
+    satellite_version: "6.2"
+    cacheable: true
+  when: clone_satellite_answers
+
+- name: set satellite_version to 6.1 if satellite_answers.yaml does not exist
+  set_fact:
+    satellite_version: "6.1"
+    cacheable: true
+  when: not clone_satellite_answers
+
+- name: Check for satellite version in metadata file
+  check_metadata_for_satellite_version:
+    metadata_path: "{{ backup_dir }}/metadata.yml"
+  register: metadata_satellite_version
+  when: clone_metadata_exists
+
+- name: setting fact - satellite_version
+  set_fact:
+    satellite_version: "{{ metadata_satellite_version.satellite_version }}"
+    cacheable: true
+  when:
+    - clone_metadata_exists
+    - metadata_satellite_version is defined
+    - metadata_satellite_version | success

--- a/roles/satellite-clone/tasks/main.yml
+++ b/roles/satellite-clone/tasks/main.yml
@@ -1,31 +1,10 @@
 ---
-- include: pre_install_check.yml
+- include_tasks: pre_install_check.yml
   when: run_pre_install_check
 
-- name: check satellite version from the config files
-  command: tar zxf {{ backup_dir }}/config_files.tar.gz  etc/foreman-installer/scenarios.d/satellite-answers.yaml --to-stdout
-  register: satellite_answers
-  ignore_errors: true
-  no_log: true
+- include_tasks: backup_check.yml
 
-- name: setting fact - satellite_answers
-  set_fact:
-    clone_satellite_answers: "{{ (satellite_answers.rc | int) == 0 }}"
-    cacheable: true
-
-- name: set satellite_version to 6.2 if satellite_answers.yaml exists
-  set_fact:
-    satellite_version: 6.2
-    cacheable: true
-  when: clone_satellite_answers
-
-- name: set satellite_version to 6.1 if satellite_answers.yaml does not exist
-  set_fact:
-    satellite_version: 6.1
-    cacheable: true
-  when: not clone_satellite_answers
-
-- include: backup_check.yml
+- include_tasks: backup_satellite_version_check.yml
 
 # Identify hostname from backup config file
 - name: Identify the hostname from the backup config tar file
@@ -124,10 +103,10 @@
 # Install Satellite packages
 - name: Install Satellite 6.1 packages
   yum: name=katello state=latest
-  when: satellite_version == 6.1
-- name: Install Satellite 6.2 packages
+  when: satellite_version == "6.1" 
+- name: "Install Satellite {{ satellite_version }} packages"
   yum: name=satellite state=latest
-  when: satellite_version == 6.2
+  when: satellite_version in ["6.2", "6.3"]
 
 # The postgres user is created after installing postgresql packages, so
 # we perform this owner/group change at this point rather than earlier
@@ -175,7 +154,7 @@
 # Workaround for Issue #72 -  satellite-clone playbook fails if /etc/katello-installer isn't present.
 - name: Create /etc/katello-installer folder
   file: path=/etc/katello-installer state=directory mode=0755
-  when: satellite_version == 6.2
+  when: satellite_version in ["6.2", "6.3"]
 
 # Restore Config
 - name: untar config files (for cloning only)
@@ -190,17 +169,33 @@
   command: restorecon -R /
   when: restorecon
 
-# Run Satellite installer
-- name: run Satellite 6.1 installer
+# This file tells the candlepin puppet module in the Satellite installer that
+# candlepin is already set up. We remove it so candlepin is set up correctly.
+- name: Remove cpdb_done file
+  file:
+    path: /var/lib/candlepin/cpdb_done
+    state: absent
+
+- name: Run Satellite 6.1 installer
   command: katello-installer --capsule-dns false --capsule-dhcp false --capsule-tftp false
-  when: satellite_version == 6.1
-- name: run Satellite 6.2 installer
+  when: satellite_version == "6.1"
+
+- name: "Run Satellite 6.2 installer"
   command: satellite-installer --scenario satellite --foreman-proxy-dns false --foreman-proxy-dhcp false --foreman-proxy-tftp false --foreman-ipa-authentication false
-  when: satellite_version == 6.2
+  environment:
+    HOSTNAME: "{{ hostname }}"
+  when: satellite_version == "6.2"
+
+- name: "Run Satellite 6.3 installer"
+  command: satellite-installer --scenario satellite --foreman-proxy-dns false --foreman-proxy-dhcp false --foreman-proxy-tftp false --foreman-ipa-authentication false --disable-system-checks
+  environment:
+    HOSTNAME: "{{ hostname }}"
+  when: satellite_version == "6.3"
+
 
 - block:
   # restore backup data
-  - include: restore.yml
+  - include_tasks: restore.yml
 
   - name: Restart katello-service
     command: katello-service start
@@ -229,11 +224,13 @@
 
   - name: Cleanup paused tasks
     command: foreman-rake foreman_tasks:cleanup TASK_SEARCH='label ~ *' STATES='paused'  VERBOSE=true AFTER='0h'  VERBOSE=true
-    when: satellite_version == 6.2
+    when: satellite_version in ["6.2", "6.3"]
 
-  - name: Run installer upgrade (satellite 6.2 only)
+  - name: Run installer upgrade (satellite 6.2+ only)
     command: satellite-installer --upgrade
-    when: satellite_version == 6.2
+    environment:
+      HOSTNAME: "{{ hostname }}"
+    when: satellite_version in ["6.2", "6.3"]
 
   - name: Test Satellite
     command: hammer ping
@@ -243,20 +240,20 @@
 
   - name: update katello assets
     file: src=/opt/rh/ruby193/root/usr/share/gems/gems/katello-2.2.0.93/public/assets/katello dest=/usr/share/foreman/public/assets/katello
-    when: satellite_version == 6.1
+    when: satellite_version == "6.1"
   - name: update katello bastion assets
     file: src=/opt/rh/ruby193/root/usr/share/gems/gems/katello-2.2.0.93/public/assets/bastion_katello dest=/usr/share/foreman/public/assets/bastion_katello
-    when: satellite_version == 6.1
+    when: satellite_version == "6.1"
 
-  - include: reset_pulp_data.yml
+  - include_tasks: reset_pulp_data.yml
     when: not clone_pulp_data_exists and not online_backup
 
   - name: Run katello reindex for satellite 6.1 - Note that this might take hours
     command: foreman-rake katello:reindex --trace
-    when: run_katello_reindex or not clone_pulp_data_exists and satellite_version == 6.1
+    when: run_katello_reindex or not clone_pulp_data_exists and satellite_version == "6.1"
   - name: Run katello reimport for satellite 6.2 - Note that this might take hours
     command: foreman-rake katello:reimport --trace
-    when: run_katello_reindex or not clone_pulp_data_exists and satellite_version == 6.2
+    when: run_katello_reindex or not clone_pulp_data_exists and satellite_version in ["6.2", "6.3"]
 
   - name: Disassociate capsules with lifecycle environments (to avoid the cloned Satellite server talking with live capsules)
     script: disassociate_capsules.rb

--- a/roles/satellite-clone/tasks/reset_pulp_data.yml
+++ b/roles/satellite-clone/tasks/reset_pulp_data.yml
@@ -4,13 +4,19 @@
 - name: reset pulp repo importers
   command: 'mongo pulp_database --eval "db.repo_importers.update({\"scratchpad.repomd_revision\": {$exists: true}}, {$set: {\"scratchpad.repomd_revision\": null}}, {multi: true});"'
 
-- name: reset pulp data in 6.2
+- name: reset pulp data in 6.2+
   command: echo "Katello::Rpm.all.destroy_all; Katello::Erratum.all.destroy_all; Katello::PackageGroup.all.destroy_all; Katello::PuppetModule.all.destroy_all; Katello::DockerManifest.all.destroy_all; Katello::DockerTag.all.destroy_all" | foreman-rake console
-  when: satellite_version == 6.2
+  when: satellite_version in ["6.2", "6.3"]
 
 - name: reset pulp data in 6.1
   command: echo "Katello::Erratum.all.destroy_all" | foreman-rake console
-  when: satellite_version == 6.1
+  when: satellite_version == "6.1"
 
-- name: migrate pulp db
+- name: stop pulp services
+  command: katello-service stop --only httpd,pulp_workers,pulp_celerybeat,pulp_resource_manager,pulp_streamer
+
+- name: migrate pulp db (reset pulp data)
   command: sudo -u apache pulp-manage-db
+
+- name: start pulp services
+  command: katello-service start --only httpd,pulp_workers,pulp_celerybeat,pulp_resource_manager,pulp_streamer

--- a/roles/satellite-clone/tasks/restore.yml
+++ b/roles/satellite-clone/tasks/restore.yml
@@ -6,10 +6,10 @@
   service: name=postgresql state=stopped
 
 - name: Restore postgresql data
-  command: tar --selinux --overwrite -xf {{ backup_dir }}/pgsql_data.tar.gz -C /
+  command: "tar --selinux --overwrite -xf {{ backup_dir }}/pgsql_data.tar.gz -C /"
   when: standard_backup
 
-- include: restore_psql_dump.yml
+- include_tasks: restore_psql_dump.yml
   when: online_backup
 
 - name: Restore pulp data
@@ -23,7 +23,7 @@
 - name: Start mongod
   service: name=mongod state=started
 
-- include: restore_mongo_dump.yml
+- include_tasks: restore_mongo_dump.yml
   when: online_backup
 
 - name: migrate pulp db


### PR DESCRIPTION
This adds an ansible module to check the metadata file in the backup
for a specific version. Because metadata.yml was added in 6.2.z,
the previous check of satellite-answers is kept for older 6.2 backups.
Any backup with metadata.yml will use the metadata file as a check.

Todo:

- [x] test on 6.3 normal backup
- [x] test on 6.3 online backup
- [x] test on 6.2 backup with metadata.yml