### PR TITLE
cleanup Satellite version differences

### DIFF
--- a/roles/satellite-clone/tasks/main.yml
+++ b/roles/satellite-clone/tasks/main.yml
@@ -6,6 +6,9 @@
 
 - include_tasks: backup_satellite_version_check.yml
 
+- name: Set Satellite version dependent variables
+  include_vars: "satellite_{{ satellite_version }}.yml"
+
 # Identify hostname from backup config file
 - name: Identify the hostname from the backup config tar file
   shell: tar zxf {{ backup_dir }}/config_files.tar.gz etc/foreman-proxy/settings.yml --to-stdout | grep foreman_url |sed 's#.*/##'
@@ -101,12 +104,10 @@
   when: overwrite_etc_hosts
 
 # Install Satellite packages
-- name: Install Satellite 6.1 packages
-  yum: name=katello state=latest
-  when: satellite_version == "6.1" 
-- name: "Install Satellite {{ satellite_version }} packages"
-  yum: name=satellite state=latest
-  when: satellite_version in ["6.2", "6.3"]
+- name: Install Satellite packages
+  yum:
+    name: "{{ satellite_package }}"
+    state: latest
 
 # The postgres user is created after installing postgresql packages, so
 # we perform this owner/group change at this point rather than earlier
@@ -176,22 +177,16 @@
     path: /var/lib/candlepin/cpdb_done
     state: absent
 
-- name: Run Satellite 6.1 installer
-  command: katello-installer --capsule-dns false --capsule-dhcp false --capsule-tftp false
-  when: satellite_version == "6.1"
-
-- name: "Run Satellite 6.2 installer"
-  command: satellite-installer --scenario satellite --foreman-proxy-dns false --foreman-proxy-dhcp false --foreman-proxy-tftp false --foreman-ipa-authentication false
+- name: Run Satellite installer
   environment:
     HOSTNAME: "{{ hostname }}"
-  when: satellite_version == "6.2"
-
-- name: "Run Satellite 6.3 installer"
-  command: satellite-installer --scenario satellite --foreman-proxy-dns false --foreman-proxy-dhcp false --foreman-proxy-tftp false --foreman-ipa-authentication false --disable-system-checks
-  environment:
-    HOSTNAME: "{{ hostname }}"
-  when: satellite_version == "6.3"
-
+  command: >
+    {{ satellite_installer_cmd }}
+    {{ (satellite_scenario is defined) | ternary("--scenario", "") }} {{ satellite_scenario }}
+    --{{ capsule_puppet_module }}-dns false
+    --{{ capsule_puppet_module }}-dhcp false
+    --{{ capsule_puppet_module }}-tftp false
+    {{ satellite_installer_options | default("") }}
 
 - block:
   # restore backup data
@@ -248,12 +243,9 @@
   - include_tasks: reset_pulp_data.yml
     when: not clone_pulp_data_exists and not online_backup
 
-  - name: Run katello reindex for satellite 6.1 - Note that this might take hours
-    command: foreman-rake katello:reindex --trace
-    when: run_katello_reindex or not clone_pulp_data_exists and satellite_version == "6.1"
-  - name: Run katello reimport for satellite 6.2 - Note that this might take hours
-    command: foreman-rake katello:reimport --trace
-    when: run_katello_reindex or not clone_pulp_data_exists and satellite_version in ["6.2", "6.3"]
+  - name: "Run katello {{ verify_rake_task }} for Satellite - Note that this might take hours"
+    command: "foreman-rake katello:{{ verify_rake_task }} --trace"
+    when: run_katello_reindex or not clone_pulp_data_exists 
 
   - name: Disassociate capsules with lifecycle environments (to avoid the cloned Satellite server talking with live capsules)
     script: disassociate_capsules.rb

--- a/roles/satellite-clone/vars/satellite_6.1.yml
+++ b/roles/satellite-clone/vars/satellite_6.1.yml
@@ -1,0 +1,5 @@
+---
+satellite_package: katello
+satellite_installer_cmd: katello-installer
+capsule_puppet_module: capsule
+verify_rake_task: reindex

--- a/roles/satellite-clone/vars/satellite_6.2.yml
+++ b/roles/satellite-clone/vars/satellite_6.2.yml
@@ -1,0 +1,8 @@
+---
+satellite_package: satellite
+satellite_installer_cmd: satellite-installer
+satellite_scenario: satellite
+capsule_puppet_module: foreman-proxy
+satellite_installer_options: "--foreman-ipa-authentication false"
+verify_rake_task: reimport
+

--- a/roles/satellite-clone/vars/satellite_6.3.yml
+++ b/roles/satellite-clone/vars/satellite_6.3.yml
@@ -1,0 +1,7 @@
+---
+satellite_package: satellite
+satellite_installer_cmd: satellite-installer
+satellite_scenario: satellite
+capsule_puppet_module: foreman-proxy
+satellite_installer_options: "--foreman-ipa-authentication false --disable-system-checks"
+verify_rake_task: reimport


### PR DESCRIPTION
Used this today to clone a 6.2 instance and test a 6.3 upgrade, it worked really well. Just had some issues due to:
-  the backup didn't include the custom certs I'm using
   - easy enough to copy them over manually.
- this role trying chown postgres <backup dir>, which was on a read-only NFS mount.
  - worked around it by chown'ing it on the NFS server.

Anyway made some small code improvements. Thanks!