### PR TITLE
Fixes #342 - Quote lifecycle environment name

### DIFF
--- a/roles/satellite-clone/files/disassociate_capsules.rb
+++ b/roles/satellite-clone/files/disassociate_capsules.rb
@@ -17,8 +17,8 @@ else
   reverse_commands = []
   external_capsules.each do |capsule|
     capsule[:lifecycle_environments].each do |env|
-      `hammer -u #{username} -p #{password} --csv capsule content remove-lifecycle-environment --id #{capsule[:id]} --environment #{env} --organization "#{capsule[:organization]}"`
-      reverse_command = "hammer -u #{username} -p #{password} --csv capsule content add-lifecycle-environment --id #{capsule[:id]} --environment #{env} --organization \"#{capsule[:organization]}\""
+      `hammer -u #{username} -p #{password} --csv capsule content remove-lifecycle-environment --id #{capsule[:id]} --environment "#{env}" --organization "#{capsule[:organization]}"`
+      reverse_command = "hammer -u #{username} -p #{password} --csv capsule content add-lifecycle-environment --id #{capsule[:id]} --environment \"#{env}\" --organization \"#{capsule[:organization]}\""
       reverse_commands << reverse_command
     end
   end


### PR DESCRIPTION
fixes errors like
```
TASK [satellite-clone : Disassociate capsules with lifecycle environments (to avoid the cloned Satellite server talking with live capsules)] ***
...
stdout: Could not remove the lifecycle environment from the capsule:
  Error: too many arguments
  
  See: 'hammer capsule content remove-lifecycle-environment --help'
...
All Capsules are unassociated with any lifecycle environments. This is to avoid ...
hammer ... --csv capsule content add-lifecycle-environment --id 25 --environment Env Dev --organization "Org"
```