### PR TITLE
Support for cloning 6.4 Satellite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,10 @@
 *.swo
 
 #Log files
-logs/playbook.log
-logs/satellite-hostname.log
+logs/
 
 #Varies per deployment
 satellite-clone-vars.yml
 satellite-hostname-vars.yml
+
+cache/

--- a/README.md
+++ b/README.md
@@ -1,15 +1,20 @@
 # Satellite-clone
 
-Easily setup a Satellite 6.1, 6.2, or 6.3 server with restored backup data.
+Easily set up a Red Hat Satellite server with restored backup data.
 
 ## Getting Started
 Throughout this documentation, ensure that you understand the following terminology:
 - Source server: Existing Satellite server.
 - Target server: new server, to which Satellite server is being cloned.
 
+#### Supported Satellite Versions ####
+- 6.2
+- 6.3
+- 6.4 (remote database cloning not currently supported)
+
 #### What you need: ####
   - A blank (vanilla install) RHEL 7 server (target server). You will run the setup commands here.
-  - A backup from a 6.1, 6.2, or 6.3 Satellite server (source server) created with `katello-backup`. This backup can be with or without pulp-data, and can be from a RHEL 6 or 7 machine.
+  - A backup from a Satellite server (source server) created with `foreman-maintain` or `katello-backup`. This backup can be with or without pulp data, and can be from a RHEL 6 or 7 machine.
   - You will need a Satellite 6 subscription for the cloned machine. With the new Satellite Infrastructure [subscription model](https://access.redhat.com/solutions/3382781) you should have multiple Satellite subscriptions available.
 
 #### Setup ####

--- a/library/parse_backup_metadata.py
+++ b/library/parse_backup_metadata.py
@@ -18,7 +18,7 @@ from ansible.module_utils.basic import *
 #          - Full path (including file name) to metadata.yml
 #        required: true
 
-SUPPORTED_VERSIONS = ["6.2", "6.3"]
+SUPPORTED_VERSIONS = ["6.2", "6.3", "6.4"]
 
 def find_rpm(rpms, pattern):
     matches = [r for r in rpms if pattern.match(r)]

--- a/roles/satellite-clone/tasks/main.yml
+++ b/roles/satellite-clone/tasks/main.yml
@@ -51,7 +51,7 @@
   when: enable_repos and disable_repos_result_fail
 
 - name: Enable required repos for Satellite installation
-  command: subscription-manager repos --enable rhel-{{ ansible_distribution_major_version }}-server-rpms --enable rhel-server-rhscl-{{ ansible_distribution_major_version }}-rpms --enable rhel-{{ ansible_distribution_major_version }}-server-satellite-{{ satellite_version }}-rpms
+  command: subscription-manager repos --enable rhel-{{ ansible_distribution_major_version }}-server-rpms --enable rhel-server-rhscl-{{ ansible_distribution_major_version }}-rpms --enable rhel-{{ ansible_distribution_major_version }}-server-satellite-{{ satellite_version }}-rpms --enable rhel-7-server-satellite-maintenance-6-rpms
   ignore_errors: True
   register: enable_repos_result
   when: enable_repos
@@ -60,7 +60,7 @@
   command: subscription-manager repos --enable rhel-7-server-satellite-{{ satellite_version }}-puppet{{ puppet_version }}-rpms
   when:
     - enable_repos
-    - puppet_version | int >= 4
+    - puppet_version|int == 4
 
 - name: set fact - enable_repos_result
   set_fact:
@@ -113,6 +113,12 @@
 - name: Install Satellite packages
   yum:
     name: "{{ satellite_package }}"
+    state: latest
+
+# due to support for remote databases in 6.4 the postgres user (and server) may be missing
+- name: Install postgresql-server
+  yum:
+    name: "postgresql-server"
     state: latest
 
 # The postgres user is created after installing postgresql packages, so
@@ -170,7 +176,7 @@
   yum:
     name: puppetserver
     state: latest
-  when: puppet_version | int >= 4
+  when: puppet_version|int == 4
 
 - name: untar config files (for cloning only)
   command: tar --selinux --overwrite -xf {{ backup_dir }}/config_files.tar.gz -C /
@@ -234,13 +240,13 @@
 
   - name: Cleanup paused tasks
     command: foreman-rake foreman_tasks:cleanup TASK_SEARCH='label ~ *' STATES='paused'  VERBOSE=true AFTER='0h'  VERBOSE=true
-    when: satellite_version in ["6.2", "6.3"]
+    when: satellite_version in ["6.2", "6.3", "6.4"]
 
   - name: Run installer upgrade (satellite 6.2+ only)
     command: 'satellite-installer --upgrade {{ satellite_upgrade_options | default("") }}'
     environment:
       HOSTNAME: "{{ hostname }}"
-    when: satellite_version in ["6.2", "6.3"]
+    when: satellite_version in ["6.2", "6.3", "6.4"]
 
   - name: Test Satellite
     command: hammer ping

--- a/roles/satellite-clone/tasks/reset_pulp_data.yml
+++ b/roles/satellite-clone/tasks/reset_pulp_data.yml
@@ -6,7 +6,7 @@
 
 - name: reset pulp data in 6.2+
   command: echo "Katello::Rpm.all.destroy_all; Katello::Erratum.all.destroy_all; Katello::PackageGroup.all.destroy_all; Katello::PuppetModule.all.destroy_all; Katello::DockerManifest.all.destroy_all; Katello::DockerTag.all.destroy_all" | foreman-rake console
-  when: satellite_version in ["6.2", "6.3"]
+  when: satellite_version in ["6.2", "6.3", "6.4"]
 
 - name: reset pulp data in 6.1
   command: echo "Katello::Erratum.all.destroy_all" | foreman-rake console

--- a/roles/satellite-clone/tasks/restore_mongo_dump.yml
+++ b/roles/satellite-clone/tasks/restore_mongo_dump.yml
@@ -2,4 +2,4 @@
   command: mongo pulp_database --eval "db.dropDatabase()"
 
 - name: Restore new mongo data
-  command: mongorestore --host localhost {{ backup_dir }}/mongo_dump/pulp_database/
+  command: mongorestore --host localhost -d pulp_database {{ backup_dir }}/mongo_dump/pulp_database/

--- a/roles/satellite-clone/vars/satellite_6.4.yml
+++ b/roles/satellite-clone/vars/satellite_6.4.yml
@@ -1,0 +1,8 @@
+---
+satellite_package: satellite
+satellite_installer_cmd: satellite-installer
+satellite_scenario: satellite
+capsule_puppet_module: foreman-proxy
+satellite_installer_options: "--foreman-ipa-authentication false --disable-system-checks"
+satellite_upgrade_options: "--disable-system-checks"
+verify_rake_task: reimport


### PR DESCRIPTION
I was able to clone my satellite including pulp data with this patch!

There are a few places in the main.yml which references version 6.2, 6.3 but I didn't add 6.4 there arbitrarily. Things seem to be OK but would like some specific feedback on those omissions.