### PR TITLE
Properly dissassociate capsule lifecycle environments

### DIFF
--- a/roles/satellite-clone/files/disassociate_capsules.rb
+++ b/roles/satellite-clone/files/disassociate_capsules.rb
@@ -20,18 +20,17 @@ if external_capsule_ids.empty?
   STDOUT.puts "There are no external capsules to disassociate."
 else
   external_capsule_ids.split("\n").each do |id|
-    lifecycle_environment = run_hammer_cmd("--csv capsule content lifecycle-environments --id #{id} | tail -n+2 | awk -F, {'print $2'}").split("\n")
+    lifecycle_environment = run_hammer_cmd("--csv capsule content lifecycle-environments --id #{id} | tail -n+2 | awk -F, {'print $1'}").split("\n")
     name = run_hammer_cmd("--csv capsule info --id #{id} | tail -n+2 | awk -F, {'print $2'}").chomp
-    organization = run_hammer_cmd("--csv capsule info --id #{id}| tail -n+2 | awk -F, '{print $(NF-2)}'").chomp
-    external_capsules << {:id => id, :name => name, :lifecycle_environments => lifecycle_environment, :organization => organization}
+    external_capsules << {:id => id, :name => name, :lifecycle_environments => lifecycle_environment}
   end
 
 
   reverse_commands = []
   external_capsules.each do |capsule|
     capsule[:lifecycle_environments].each do |env|
-      run_hammer_cmd("--csv capsule content remove-lifecycle-environment --id #{capsule[:id]} --environment #{env.shellescape} --organization #{capsule[:organization].shellescape}")
-      reverse_command = prepare_hammer_cmd("--csv capsule content add-lifecycle-environment --id #{capsule[:id]} --environment #{env.shellescape} --organization #{capsule[:organization].shellescape}")
+      run_hammer_cmd("--csv capsule content remove-lifecycle-environment --id #{capsule[:id]} --environment-id #{env}")
+      reverse_command = prepare_hammer_cmd("--csv capsule content add-lifecycle-environment --id #{capsule[:id]} --environment-id #{env}")
       reverse_commands << reverse_command
     end
   end


### PR DESCRIPTION
The previous code would grab the last listed org for the capsule
and then attempt to lookup all associated lifecycle environments
by that organization.  The result is that if a capsule is associated
with 5 orgs, but only associated with the Library of one or two of them,
it may randomally decide to try to remove the lifecycle env from another org

Closes: #363 