### PR TITLE
Support cloning Satellite 6.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Throughout this documentation, ensure that you understand the following terminol
 - 6.3
 - 6.4 
 - 6.5
+- 6.6
 
 Note: cloning with a remote database is not currently supported
 

--- a/library/parse_backup_metadata.py
+++ b/library/parse_backup_metadata.py
@@ -18,7 +18,7 @@ from ansible.module_utils.basic import *
 #          - Full path (including file name) to metadata.yml
 #        required: true
 
-SUPPORTED_VERSIONS = ["6.2", "6.3", "6.4", "6.5"]
+SUPPORTED_VERSIONS = ["6.2", "6.3", "6.4", "6.5", "6.6"]
 
 def find_rpm(rpms, pattern):
     matches = [r for r in rpms if pattern.match(r)]

--- a/roles/satellite-clone/tasks/main.yml
+++ b/roles/satellite-clone/tasks/main.yml
@@ -179,7 +179,7 @@
   when: puppet_version|int == 4
 
 - name: untar config files (for cloning only)
-  command: tar --selinux --overwrite -xf {{ backup_dir }}/config_files.tar.gz -C / --exclude=var/lib/foreman/public/assets
+  command: tar --selinux --overwrite -xf {{ backup_dir }}/config_files.tar.gz -C / --exclude=var/lib/foreman/public
   when: not rhel_migration
 
 - name: untar config files (for migration only)
@@ -228,7 +228,7 @@
 
   - name: restore using foreman-maintain
     command: foreman-maintain restore --assumeyes {{ backup_dir }}
-    when: satellite_version in ["6.5"]
+    when: satellite_version in ["6.5", "6.6"]
 
   - name: Restart katello-service
     command: katello-service start
@@ -251,7 +251,7 @@
 
   - name: Cleanup paused tasks
     command: foreman-rake foreman_tasks:cleanup TASK_SEARCH='label ~ *' STATES='paused'  VERBOSE=true AFTER='0h'  VERBOSE=true
-    when: satellite_version in ["6.2", "6.3", "6.4", "6.5"]
+    when: satellite_version in ["6.2", "6.3", "6.4", "6.5", "6.6"]
 
   - name: Check if foreman-maintain-hammer.yml exists
     stat:
@@ -271,13 +271,13 @@
       state: present
       create: yes
       line: "---\n:foreman:\n  :username: admin\n  :password: changeme"
-    when: satellite_version in ["6.4", "6.5"]
+    when: satellite_version in ["6.4", "6.5", "6.6"]
 
   - name: Run installer upgrade to match latest z-version
     command: 'satellite-installer --upgrade {{ satellite_upgrade_options | default("") }}'
     environment:
       HOSTNAME: "{{ hostname }}"
-    when: satellite_version in ["6.2", "6.3", "6.4", "6.5"]
+    when: satellite_version in ["6.2", "6.3", "6.4", "6.5", "6.6"]
 
   - name: Test Satellite
     command: hammer ping

--- a/roles/satellite-clone/tasks/reset_pulp_data.yml
+++ b/roles/satellite-clone/tasks/reset_pulp_data.yml
@@ -6,7 +6,7 @@
 
 - name: reset pulp data in 6.2+
   command: echo "Katello::Rpm.all.destroy_all; Katello::Erratum.all.destroy_all; Katello::PackageGroup.all.destroy_all; Katello::PuppetModule.all.destroy_all; Katello::DockerManifest.all.destroy_all; Katello::DockerTag.all.destroy_all" | foreman-rake console
-  when: satellite_version in ["6.2", "6.3", "6.4", "6.5"]
+  when: satellite_version in ["6.2", "6.3", "6.4", "6.5", "6.6"]
 
 - name: reset pulp data in 6.1
   command: echo "Katello::Erratum.all.destroy_all" | foreman-rake console

--- a/roles/satellite-clone/vars/satellite_6.6.yml
+++ b/roles/satellite-clone/vars/satellite_6.6.yml
@@ -1,0 +1,8 @@
+---
+satellite_package: satellite
+satellite_installer_cmd: satellite-installer
+satellite_scenario: satellite
+capsule_puppet_module: foreman-proxy
+satellite_installer_options: "--foreman-ipa-authentication false --reset-puppet-server-ssl-chain-filepath --disable-system-checks"
+satellite_upgrade_options: "--disable-system-checks"
+verify_rake_task: reimport


### PR DESCRIPTION
I tested this as fully working to clone a Sat 6.6 from the latest build.

Since the repos aren't available publicly you'll need to make this change to tasks/main.yaml - note the OHSNAP hostname you'll need to provide:

```
 - name: Enable required repos for Satellite installation
-  command: subscription-manager repos --enable rhel-{{ ansible_distribution_major_version }}-server-rpms --enable rhel-server-rhscl-{{ ansible_distribution_major_version }}-rpms --enable rhel-{{ ansible_distribution_major_version 
+  #command: subscription-manager repos --enable rhel-{{ ansible_distribution_major_version }}-server-rpms --enable rhel-server-rhscl-{{ ansible_distribution_major_version }}-rpms --enable rhel-{{ ansible_distribution_major_version
+  command: subscription-manager repos --enable rhel-{{ ansible_distribution_major_version }}-server-rpms --enable rhel-server-rhscl-{{ ansible_distribution_major_version }}-rpms
   ignore_errors: True
   register: enable_repos_result
   when: enable_repos
 
+- name: Add 6.6 repos
+  command: curl -o /etc/yum.repos.d/satellite.repo http://<OHSNAP>/api/releases/6.6.0/el7/satellite/repo_file
+
```

This also requires a foreman-maintain patch on the destination Satellite. It can be cloned successfully without but most Katello pages will be blank. https://github.com/theforeman/foreman_maintain/pull/282