### PR TITLE
Disables hammer-cli-csv module and ignore warnings in hammer commands

### DIFF
--- a/roles/satellite-clone/files/disassociate_capsules.rb
+++ b/roles/satellite-clone/files/disassociate_capsules.rb
@@ -14,14 +14,19 @@ def run_hammer_cmd(command)
   `#{command}`
 end
 
+def get_info_from_hammer(command, column=1)
+  bash_parse = " | grep -v \"Warning:\" | tail -n+2 | awk -F, {'print $#{column}'}"
+  run_hammer_cmd(command + bash_parse)
+end
+
 external_capsules = []
-external_capsule_ids = run_hammer_cmd("--csv capsule list --search 'feature = \"Pulp Node\"' | grep -v \"Warning:\" | tail -n+2 | awk -F, {'print $1'}")
+external_capsule_ids = get_info_from_hammer("--csv capsule list --search 'feature = \"Pulp Node\"'")
 if external_capsule_ids.empty?
   STDOUT.puts "There are no external capsules to disassociate."
 else
   external_capsule_ids.split("\n").each do |id|
-    lifecycle_environment = run_hammer_cmd("--csv capsule content lifecycle-environments --id #{id} | tail -n+2 | awk -F, {'print $1'}").split("\n")
-    name = run_hammer_cmd("--csv capsule info --id #{id} | tail -n+2 | awk -F, {'print $2'}").chomp
+    lifecycle_environment = get_info_from_hammer("--csv capsule content lifecycle-environments --id #{id}").split("\n")
+    name = get_info_from_hammer("--csv capsule info --id #{id}", 2).chomp
     external_capsules << {:id => id, :name => name, :lifecycle_environments => lifecycle_environment}
   end
 

--- a/roles/satellite-clone/tasks/main.yml
+++ b/roles/satellite-clone/tasks/main.yml
@@ -210,6 +210,13 @@
     state: absent
     path: /etc/tomcat/conf.d/jmx.conf
 
+# This no longer is supported in 6.6, but was still found enabled in some backups
+- name: Remove hammer csv module
+  file:
+    state: absent
+    path: /etc/hammer/cli.modules.d/csv.yml
+  when: satellite_version in ["6.6"]
+
 - name: Run Satellite installer
   environment:
     HOSTNAME: "{{ hostname }}"


### PR DESCRIPTION
This disables the hammer-cli-csv module by removing it's configuration file from the hammer config. This is an issue on some 6.6 installations, where the file is still present.

A fix could still be needed in the installer, but this commit will fix things for any current backups by ensuring the file is removed.

This also updates the disassociate_capsules script to exclude warnings for all hammer commands where we are parsing the output. It also DRYs up our parsing into one function to make updating this area easier.

You can test just the "disassociate_capsules" script on a Satellite that includes capsules associated with a lifecycle environment. The script will disassociate them and give instructions for reversal.