### PR TITLE
Add custom module to parse YAML in config file

### DIFF
--- a/library/get_value_from_yaml_in_tarball.py
+++ b/library/get_value_from_yaml_in_tarball.py
@@ -1,0 +1,81 @@
+import yaml
+import tarfile
+from ansible.module_utils.basic import *
+from functools import reduce
+import operator
+
+DOCUMENTATION = '''
+---
+module: get_value_from_yaml_in_tarball
+description:
+    - Return value from a YAML file that is in a tarball
+options:
+    tarball:
+        description:
+          - path to tarball that contains the target yaml file.
+        required: true
+    target_file:
+        description:
+          - Path of target YAML file
+        required: true
+    keys:
+        description:
+          - List of key(s) to find value in file. It can take multiple values for nested keys.
+            For example: ["foreman_proxy", "dhcp"] or ["satellite_version"]
+        required: true
+'''
+
+EXAMPLES = '''
+- name: Get puppet user from Satellite answers
+  get_value_from_yaml_in_tarball:
+    tarball: "/path/to/config_files.tar.gz"
+    target_file: "etc/foreman-installer/scenarios.d/satellite-answers.yaml"
+    keys: ["puppet", "user"]
+  register: puppet_user
+
+  then you can use puppet_user.value
+'''
+
+BACKUP_CONFIG = "config_files.tar.gz"
+
+# Takes keys in the format ['foo', 'bar']
+# when the dict looks like
+# { "foo": { "bar": "hi" }}
+# will return None if it a key doesn't exist
+def get_value(data, keys):
+    try:
+        return reduce(operator.getitem, keys, data)
+    except KeyError:
+        return None
+
+
+def get_value_from_tarball(params):
+    config_tar = tarfile.open(params["tarball"])
+    answers_file = config_tar.extractfile(params["target_file"])
+    answers = yaml.load(answers_file.read())
+    found_value = get_value(answers, params['keys'])
+    # The value itself can be false, so only check for NoneType
+    if found_value is not None:
+        return True, dict(msg="Value found!", changed=False, value=found_value)
+    else:
+        msg = "Keys {} were not found in {}!".format(
+            params["keys"], params["target_file"])
+        return False, dict(msg=msg)
+
+
+def main():
+    fields = {
+        "tarball": {"required": True, "type": "str"},
+        "target_file": {"required": True, "type": "str"},
+        "keys": {"required": True, "type": "list"}
+    }
+    module = AnsibleModule(argument_spec=fields)
+    success, result = get_value_from_tarball(module.params)
+    if success:
+        module.exit_json(**result)
+    else:
+        module.fail_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/satellite-clone/defaults/main.yml
+++ b/roles/satellite-clone/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 # more info about these variables can be found in satellite-clone-vars.sample.yml in the root directory of this project
 backup_dir: /backup
+satellite_answers_path: "etc/foreman-installer/scenarios.d/satellite-answers.yaml"
+config_files_path: "{{ backup_dir }}/config_files.tar.gz"
 disable_firewall: False
 run_katello_reindex: False
 run_pre_install_check: True

--- a/roles/satellite-clone/tasks/main.yml
+++ b/roles/satellite-clone/tasks/main.yml
@@ -9,19 +9,21 @@
 - name: Set Satellite version dependent variables
   include_vars: "satellite_{{ satellite_version }}.yml"
 
-# Identify hostname from backup config file
 - name: Identify the hostname from the backup config tar file
-  shell: tar zxf {{ backup_dir }}/config_files.tar.gz etc/foreman-proxy/settings.yml --to-stdout | grep foreman_url |sed 's#.*/##'
+  get_value_from_yaml_in_tarball:
+    tarball: "{{ config_files_path }}"
+    target_file: "etc/foreman-proxy/settings.yml"
+    keys: [":foreman_url"]
   register: backup_hostname
 
-- name: setting fact - hostname
+- name: Set backup_hostname variable
   set_fact:
-    hostname: "{{ backup_hostname.stdout }}"
+    hostname: "{{ backup_hostname.value | urlsplit('hostname') }}"
     cacheable: true
 
 - name: Check that the hostname is not none
   fail: msg="Unable to derive Satellite hostname from the backup config file - value ({{ hostname }}) doesn't look right"
-  when: backup_hostname.stderr
+  when: backup_hostname|length == 0
 
 - name: Check that the registration variables (activationkey, org) are updated
   fail: msg="Please update the variables in /etc/satellite-clone/satellite-clone-vars.yml"


### PR DESCRIPTION
For Satellite answers and other configs, it helps if we have a way to parse the yaml config files inside the tarball. This commit adds that custom module and updates a place where we parse the configs from the shell.