### PR TITLE
Fixes #29871 - Fix Hammer deprecation warning with lce

### DIFF
--- a/roles/satellite-clone/files/disassociate_capsules.rb
+++ b/roles/satellite-clone/files/disassociate_capsules.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/ruby
 
 require 'shellwords'
+require 'rubygems'
 
 @username = "admin"
 @password = "changeme"
@@ -19,6 +20,10 @@ def get_info_from_hammer(command, column=1)
   run_hammer_cmd(command + bash_parse)
 end
 
+def capsule_lce_args(action, capsule_id, env, lifecycle)
+  "--csv capsule content #{action}-lifecycle-environment --id #{capsule_id} --#{lifecycle ? "lifecycle-" : ""}environment-id #{env}"
+end
+
 external_capsules = []
 external_capsule_ids = get_info_from_hammer("--csv capsule list --search 'feature = \"Pulp Node\"'")
 if external_capsule_ids.empty?
@@ -30,13 +35,19 @@ else
     external_capsules << {:id => id, :name => name, :lifecycle_environments => lifecycle_environment}
   end
 
-
   reverse_commands = []
+  satellite_version = ARGV[0].to_f
   external_capsules.each do |capsule|
     capsule[:lifecycle_environments].each do |env|
-      run_hammer_cmd("--csv capsule content remove-lifecycle-environment --id #{capsule[:id]} --environment-id #{env}")
-      reverse_command = prepare_hammer_cmd("--csv capsule content add-lifecycle-environment --id #{capsule[:id]} --environment-id #{env}")
-      reverse_commands << reverse_command
+      if Gem::Version.new(satellite_version) > Gem::Version.new(6.5)
+        run_hammer_cmd(capsule_lce_args("remove", capsule[:id], env, true))
+        reverse_command = prepare_hammer_cmd(capsule_lce_args("add", capsule[:id], env, true))
+        reverse_commands << reverse_command
+      else
+        run_hammer_cmd(capsule_lce_args("remove", capsule[:id], env, false))
+        reverse_command = prepare_hammer_cmd(capsule_lce_args("add", capsule[:id], env, false))
+        reverse_commands << reverse_command
+      end
     end
   end
 

--- a/roles/satellite-clone/tasks/main.yml
+++ b/roles/satellite-clone/tasks/main.yml
@@ -309,7 +309,7 @@
     when: run_katello_reindex or not clone_pulp_data_exists 
 
   - name: Disassociate capsules with lifecycle environments (to avoid the cloned Satellite server talking with live capsules)
-    script: disassociate_capsules.rb
+    script: disassociate_capsules.rb {{ satellite_version }}
     register: disassociate_capsules
 
   - name: set fact - disassociate_capsules


### PR DESCRIPTION
Before on 6.5 below:
```bash
TASK [satellite-clone : Disassociate capsules with lifecycle environments (to avoid the cloned Satellite server talking with live capsules)] **********************************************************************
Friday 15 May 2020  12:35:40 -0400 (0:00:00.234)       1:07:09.580 ************ 
changed: [localhost]

stdout: All Capsules are unassociated with any lifecycle environments. This is to avoid any syncing errors with your original Satellite and any interference with existing infrastructure. To reverse these changes, run the following commands, making sure to replace the credentials with your own.
hammer -u admin -p changeme --csv capsule content add-lifecycle-environment --id 2 --environment-id 2

stderr: Warning: Option --environment-id is deprecated. Use --lifecycle-environment-id instead
```
After:

6.6:
```bash
TASK [satellite-clone : Disassociate capsules with lifecycle environments (to avoid the cloned Satellite server talking with live capsules)] *****************************************************************
Wednesday 20 May 2020  14:54:35 +0000 (0:00:00.076)       1:03:04.322 *********
changed: [localhost]

stdout: All Capsules are unassociated with any lifecycle environments. This is to avoid any syncing errors with your original Satellite and any interference with existing infrastructure. To reverse these changes, run the following commands, making sure to replace the credentials with your own.
hammer -u admin -p changeme --csv capsule content add-lifecycle-environment --id 2 --lifecycle-environment-id 2
```
6.5:
```bash
TASK [satellite-clone : Disassociate capsules with lifecycle environments (to avoid the cloned Satellite server talking with live capsules)] **********************************************************************
Monday 18 May 2020  16:00:31 -0400 (0:00:00.228)       1:08:06.776 ************ 
changed: [localhost]

stdout: All Capsules are unassociated with any lifecycle environments. This is to avoid any syncing errors with your original Satellite and any interference with existing infrastructure. To reverse these changes, run the following commands, making sure to replace the credentials with your own.
hammer -u admin -p changeme --csv capsule content add-lifecycle-environment --id 2 --environment-id 2
```

Starting to kick off tests on Dolly