### PR TITLE
On 6.8+ install selinux packages

### DIFF
--- a/roles/satellite-clone/defaults/main.yml
+++ b/roles/satellite-clone/defaults/main.yml
@@ -17,3 +17,4 @@ overwrite_etc_hosts: True
 puppet_version: 3
 check_networking_interfaces: True
 sp_features_table_name: smart_proxy_features
+selinux_packages: []

--- a/roles/satellite-clone/tasks/main.yml
+++ b/roles/satellite-clone/tasks/main.yml
@@ -184,6 +184,13 @@
     state: latest
   when: puppet_version|int == 4
 
+  # Because of https://projects.theforeman.org/issues/30506
+- name: Install Satellite SELinux packages for 6.8 and above
+  yum:
+    name: "{{ selinux_packages | join(',') }}"
+    state: present
+  when: selinux_packages | length > 0
+
 - name: untar config files (for cloning only)
   command: tar --selinux --overwrite -xf {{ backup_dir }}/config_files.tar.gz -C / --exclude=var/lib/foreman/public
 

--- a/roles/satellite-clone/vars/satellite_6.8.yml
+++ b/roles/satellite-clone/vars/satellite_6.8.yml
@@ -6,3 +6,7 @@ capsule_puppet_module: foreman-proxy
 satellite_installer_options: "--foreman-ipa-authentication false --reset-puppet-server-ssl-chain-filepath --disable-system-checks"
 satellite_upgrade_options: "--disable-system-checks"
 verify_rake_task: reimport
+selinux_packages:
+  - crane-selinux
+  - foreman-selinux
+  - katello-selinux


### PR DESCRIPTION
They were dropped as dependicnes of the satellite package which now causes the untar operation to fail.

Worked fine on my test box, will kick off dolly on the pr and post the results. 