### PR TITLE
Remove code related to Puppet version 4

### DIFF
--- a/library/parse_backup_metadata.py
+++ b/library/parse_backup_metadata.py
@@ -38,15 +38,6 @@ def get_rpm_version(rpms, pattern, hyphen_split=1, version_split=2):
         return False
 
 
-def get_puppet_version(puppet_agent_version, puppet_rpm_version):
-    error_msg = "Puppet version not found"
-    # Only puppet 4+ has puppet-agent rpm
-    if puppet_agent_version:
-        return puppet_agent_version
-    else:
-        raise error_msg
-
-
 def parse_backup_metadata(params):
     with open(params["metadata_path"]) as data_file:
         data = yaml.load(data_file)
@@ -54,9 +45,6 @@ def parse_backup_metadata(params):
     rpm_key = ":rpms" if ":rpms" in data else "rpms"
     rpms = data[rpm_key]
     satellite_version = get_rpm_version(rpms, "^satellite-[\d+].*")
-    puppet_agent_version = get_rpm_version(rpms, "^puppet-agent-[\d+].*", 2, 1)
-    puppet_rpm_version = get_rpm_version(rpms, "^puppet-[\d+].*", 1, 1)
-    puppet_version = get_puppet_version(puppet_agent_version, puppet_rpm_version)
 
     if not satellite_version or satellite_version not in SUPPORTED_VERSIONS:
         msg = "Satellite version is not supported or found. " \
@@ -65,7 +53,6 @@ def parse_backup_metadata(params):
 
     msg = "{0} backup found".format(satellite_version)
     result = dict(satellite_version=satellite_version,
-                  puppet_version=puppet_version,
                   msg=msg,
                   changed=False)
     return True, result

--- a/roles/satellite-clone/defaults/main.yml
+++ b/roles/satellite-clone/defaults/main.yml
@@ -14,7 +14,6 @@ disable_postgres_triggers: True
 restorecon: False
 skip_satellite_rpm_check: False
 overwrite_etc_hosts: True
-puppet_version: 3
 check_networking_interfaces: True
 sp_features_table_name: smart_proxy_features
 selinux_packages: []

--- a/roles/satellite-clone/tasks/backup_satellite_version_check.yml
+++ b/roles/satellite-clone/tasks/backup_satellite_version_check.yml
@@ -17,7 +17,6 @@
 - name: setting fact - satellite_version
   set_fact:
     satellite_version: "{{ backup_metadata.satellite_version }}"
-    puppet_version: "{{ backup_metadata.puppet_version }}"
   when:
     - clone_metadata_exists
     - backup_metadata is defined

--- a/roles/satellite-clone/tasks/main.yml
+++ b/roles/satellite-clone/tasks/main.yml
@@ -60,12 +60,6 @@
   register: enable_repos_result
   when: enable_repos
 
-- name: "Enable puppet repos"
-  command: subscription-manager repos --enable rhel-7-server-satellite-{{ satellite_version }}-puppet{{ puppet_version }}-rpms
-  when:
-    - enable_repos
-    - puppet_version|int == 4
-
 - name: set fact - enable_repos_result
   set_fact:
     enable_repos_result_fail: "{{ (enable_repos_result.rc | int) != 0}}"
@@ -165,15 +159,6 @@
       Please move the backup directory to a different directory with the correct
       permissions. Avoid using /root.
   when: clone_foreman_dump_exists and clone_candlepin_dump_exists and (clone_no_foreman_dump_access or clone_no_candlepin_dump_access)
-
-# If there is no puppet user, the extracted config files will not have the correct puppet
-# user/group permissions with puppet 4. Installing puppetserver before extracting config_files
-# fixes this issue.
-- name: Install puppetserver to create puppet user
-  yum:
-    name: puppetserver
-    state: latest
-  when: puppet_version|int == 4
 
   # Because of https://projects.theforeman.org/issues/30506
 - name: Install Satellite SELinux packages for 6.8 and above


### PR DESCRIPTION
Puppetserver 4 was only present on Satellite 6.3. At present, the oldest
supported Satellite release is Satellite 6.5. So code related to
Puppetserver 4 should be removed.