### PR TITLE
Disable Smart Proxy Realm plugin

### DIFF
--- a/docs/satellite-clone.md
+++ b/docs/satellite-clone.md
@@ -25,7 +25,7 @@
 
 ### After Cloning ###
   - On the target server, refreshing the manifest will invalidate the source server's manifest.
-  - DHCP, DNS, TFTP, and IPA authentication will be disabled during the install to avoid configuration errors. If you want to use provisioning on the target server, you will have to manually re-enable these settings after the playbook run.
+  - DHCP, DNS, TFTP, Realm, and IPA authentication will be disabled during the install to avoid configuration errors. If you want to use provisioning on the target server, you will have to manually re-enable these settings after the playbook run.
   - If you are using Remote Execution, you will have to re-copy the ssh keys to your clients. The keys are regenerate during the install portion of the clone process.
   - On the target server, the capsules will be unassociated with Lifecycle environments to avoid any interference with existing infrastructure. Instructions to reverse these changes can be found in `logs/reassociate_capsules.txt` under Satellite Clone's root directory
 

--- a/roles/satellite-clone/tasks/main.yml
+++ b/roles/satellite-clone/tasks/main.yml
@@ -220,6 +220,7 @@
     --{{ capsule_puppet_module }}-dns false
     --{{ capsule_puppet_module }}-dhcp false
     --{{ capsule_puppet_module }}-tftp false
+    --{{ capsule_puppet_module }}-realm false
     {{ satellite_installer_options | default("") }}
 
 - block:


### PR DESCRIPTION
Similar to 5d94c6ee25eccff05c8f894217aed6245e186d34 this disables realm integration on cloning. This is because the new host is usually not enrolled in IPA so the files it tries to read are not present. That causes clones to fail.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1965844