### PR TITLE
Remove capsule_puppet_module variable

### DIFF
--- a/roles/satellite-clone/tasks/main.yml
+++ b/roles/satellite-clone/tasks/main.yml
@@ -217,9 +217,9 @@
   command: >
     {{ satellite_installer_cmd }}
     {{ (satellite_scenario is defined) | ternary("--scenario", "") }} {{ satellite_scenario }}
-    --{{ capsule_puppet_module }}-dns false
-    --{{ capsule_puppet_module }}-dhcp false
-    --{{ capsule_puppet_module }}-tftp false
+    --foreman-proxy-dns false
+    --foreman-proxy-dhcp false
+    --foreman-proxy-tftp false
     {{ satellite_installer_options | default("") }}
 
 - block:

--- a/roles/satellite-clone/vars/satellite_6.5.yml
+++ b/roles/satellite-clone/vars/satellite_6.5.yml
@@ -2,7 +2,6 @@
 satellite_package: satellite
 satellite_installer_cmd: satellite-installer
 satellite_scenario: satellite
-capsule_puppet_module: foreman-proxy
 satellite_installer_options: "--foreman-ipa-authentication false --reset-puppet-server-ssl-chain-filepath --disable-system-checks"
 satellite_upgrade_options: "--upgrade --disable-system-checks"
 verify_rake_task: reimport

--- a/roles/satellite-clone/vars/satellite_6.6.yml
+++ b/roles/satellite-clone/vars/satellite_6.6.yml
@@ -2,7 +2,6 @@
 satellite_package: satellite
 satellite_installer_cmd: satellite-installer
 satellite_scenario: satellite
-capsule_puppet_module: foreman-proxy
 satellite_installer_options: "--foreman-ipa-authentication false --reset-puppet-server-ssl-chain-filepath --disable-system-checks"
 satellite_upgrade_options: "--upgrade --disable-system-checks"
 verify_rake_task: reimport

--- a/roles/satellite-clone/vars/satellite_6.7.yml
+++ b/roles/satellite-clone/vars/satellite_6.7.yml
@@ -2,7 +2,6 @@
 satellite_package: satellite
 satellite_installer_cmd: satellite-installer
 satellite_scenario: satellite
-capsule_puppet_module: foreman-proxy
 satellite_installer_options: "--foreman-ipa-authentication false --reset-puppet-server-ssl-chain-filepath --disable-system-checks"
 satellite_upgrade_options: "--upgrade --disable-system-checks"
 verify_rake_task: reimport

--- a/roles/satellite-clone/vars/satellite_6.8.yml
+++ b/roles/satellite-clone/vars/satellite_6.8.yml
@@ -2,7 +2,6 @@
 satellite_package: satellite
 satellite_installer_cmd: satellite-installer
 satellite_scenario: satellite
-capsule_puppet_module: foreman-proxy
 satellite_installer_options: "--foreman-ipa-authentication false --reset-puppet-server-ssl-chain-filepath --disable-system-checks"
 satellite_upgrade_options: "--disable-system-checks"
 verify_rake_task: reimport

--- a/roles/satellite-clone/vars/satellite_6.9.yml
+++ b/roles/satellite-clone/vars/satellite_6.9.yml
@@ -2,7 +2,6 @@
 satellite_package: satellite
 satellite_installer_cmd: satellite-installer
 satellite_scenario: satellite
-capsule_puppet_module: foreman-proxy
 
 # See the following issues for installer options
 # https://github.com/RedHatSatellite/satellite-clone/issues/268


### PR DESCRIPTION
In d42eca22bff6818f36a888e986b76313e8cef7b9 support for Satellite 6.1 was dropped. This was the last version that needed the capsule module. Since 6.2 it's always the same.