### PR TITLE
Bug fixes and style improvements to Capsule LCE disassociation script

### DIFF
--- a/roles/satellite-clone/files/disassociate_capsules.rb
+++ b/roles/satellite-clone/files/disassociate_capsules.rb
@@ -12,8 +12,7 @@ def prepare_hammer_cmd(command)
 end
 
 def run_hammer_cmd(command)
-  command = prepare_hammer_cmd(command)
-  `#{command}`
+  `#{prepare_hammer_cmd(command)}`
 end
 
 def get_ids_from_hammer(command, search = nil)

--- a/roles/satellite-clone/files/disassociate_capsules.rb
+++ b/roles/satellite-clone/files/disassociate_capsules.rb
@@ -30,9 +30,10 @@ if external_capsule_ids.empty?
   STDOUT.puts "There are no external capsules to disassociate."
 else
   external_capsule_ids.split("\n").each do |id|
-    lifecycle_environment = get_info_from_hammer("--csv capsule content lifecycle-environments --id #{id}").split("\n")
-    name = get_info_from_hammer("--csv capsule info --id #{id}", 2).chomp
-    external_capsules << {:id => id, :name => name, :lifecycle_environments => lifecycle_environment}
+    external_capsules << {
+      id: id,
+      lifecycle_environments: get_info_from_hammer("--csv capsule content lifecycle-environments --id #{id}").split("\n")
+    }
   end
 
   reverse_commands = []

--- a/roles/satellite-clone/files/disassociate_capsules.rb
+++ b/roles/satellite-clone/files/disassociate_capsules.rb
@@ -25,8 +25,6 @@ def capsule_lce_args(action, capsule_id, env)
 end
 
 external_capsule_ids = get_info_from_hammer("--csv capsule list --search 'feature = \"Pulp Node\"'")
-STDOUT.puts "There are no external capsules to disassociate." if external_capsule_ids.empty?
-
 external_capsules = external_capsule_ids.split("\n").map do |id|
   { id: id, lifecycle_environments: get_info_from_hammer("--csv capsule content lifecycle-environments --id #{id}").split("\n") }
 end
@@ -38,9 +36,15 @@ reverse_commands = external_capsules.map do |capsule|
   end
 end.flatten
 
-unless reverse_commands.empty?
-  STDOUT.puts "All Capsules are unassociated with any lifecycle environments. This is to avoid any syncing errors with your original Satellite " \
-              "and any interference with existing infrastructure. To reverse these changes, run the following commands," \
-              " making sure to replace the credentials with your own."
+if reverse_commands.empty?
+  STDOUT.puts "There were no associated lifecycle environments to disassociate from external capsules."
+else
+  STDOUT.puts <<~MESSAGE
+    Any external Capsules have been disassociated with any lifecycle environments.
+    This is to avoid any syncing errors with your original Satellite and any
+    interference with existing infrastructure. To reverse these changes, run the
+    following commands, making sure to replace the credentials with your own:
+
+  MESSAGE
   reverse_commands.each { |command| STDOUT.puts command }
 end

--- a/roles/satellite-clone/files/disassociate_capsules.rb
+++ b/roles/satellite-clone/files/disassociate_capsules.rb
@@ -38,7 +38,9 @@ reverse_commands = external_capsules.map do |capsule|
   end
 end.flatten
 
-STDOUT.puts "All Capsules are unassociated with any lifecycle environments. This is to avoid any syncing errors with your original Satellite " \
-            "and any interference with existing infrastructure. To reverse these changes, run the following commands," \
-            " making sure to replace the credentials with your own." unless reverse_commands.empty?
-reverse_commands.each { |command| STDOUT.puts command }
+unless reverse_commands.empty?
+  STDOUT.puts "All Capsules are unassociated with any lifecycle environments. This is to avoid any syncing errors with your original Satellite " \
+              "and any interference with existing infrastructure. To reverse these changes, run the following commands," \
+              " making sure to replace the credentials with your own."
+  reverse_commands.each { |command| STDOUT.puts command }
+end

--- a/roles/satellite-clone/files/disassociate_capsules.rb
+++ b/roles/satellite-clone/files/disassociate_capsules.rb
@@ -17,18 +17,15 @@ end
 
 def get_info_from_hammer(command, column=1)
   bash_parse = " | grep -v \"Warning:\" | tail -n+2 | awk -F, {'print $#{column}'}"
-  run_hammer_cmd(command + bash_parse)
+  run_hammer_cmd(command + bash_parse).split("\n")
 end
 
 def capsule_lce_args(action, capsule_id, env)
   "--csv capsule content #{action}-lifecycle-environment --id #{capsule_id} --lifecycle-environment-id #{env}"
 end
 
-external_capsule_lifecycle_environments = get_info_from_hammer("--csv capsule list --search 'feature = \"Pulp Node\"'").split("\n").map do |id|
-  {
-    capsule_id: id,
-    lifecycle_environments: get_info_from_hammer("--csv capsule content lifecycle-environments --id #{id}").split("\n")
-  }
+external_capsule_lifecycle_environments = get_info_from_hammer("--csv capsule list --search 'feature = \"Pulp Node\"'").map do |id|
+  { capsule_id: id, lifecycle_environments: get_info_from_hammer("--csv capsule content lifecycle-environments --id #{id}") }
 end
 
 reverse_commands = external_capsule_lifecycle_environments.map do |association|

--- a/roles/satellite-clone/files/disassociate_capsules.rb
+++ b/roles/satellite-clone/files/disassociate_capsules.rb
@@ -24,15 +24,17 @@ def capsule_lce_args(action, capsule_id, env)
   "--csv capsule content #{action}-lifecycle-environment --id #{capsule_id} --lifecycle-environment-id #{env}"
 end
 
-external_capsule_ids = get_info_from_hammer("--csv capsule list --search 'feature = \"Pulp Node\"'")
-external_capsules = external_capsule_ids.split("\n").map do |id|
-  { id: id, lifecycle_environments: get_info_from_hammer("--csv capsule content lifecycle-environments --id #{id}").split("\n") }
+external_capsule_lifecycle_environments = get_info_from_hammer("--csv capsule list --search 'feature = \"Pulp Node\"'").split("\n").map do |id|
+  {
+    capsule_id: id,
+    lifecycle_environments: get_info_from_hammer("--csv capsule content lifecycle-environments --id #{id}").split("\n")
+  }
 end
 
-reverse_commands = external_capsules.map do |capsule|
-  capsule[:lifecycle_environments].map do |env|
-    run_hammer_cmd(capsule_lcs_args("remove", capsule[:id], env))
-    prepare_hammer_cmd(capsule_lce_args("add", capsule[:id], env))
+reverse_commands = external_capsule_lifecycle_environments.map do |association|
+  association[:lifecycle_environments].map do |env|
+    run_hammer_cmd(capsule_lcs_args("remove", association[:capsule_id], env))
+    prepare_hammer_cmd(capsule_lce_args("add", association[:capsule_id], env))
   end
 end.flatten
 


### PR DESCRIPTION
Prior to this commit, the Capsule names are collected but never used.
Removing the collection of Capsule names speeds up execution by avoiding
potentially many redundant calls to `hammer --csv capsule info`.