### PR TITLE
Always use katello:reimport rake, never katello:reindex

### DIFF
--- a/roles/satellite-clone/defaults/main.yml
+++ b/roles/satellite-clone/defaults/main.yml
@@ -6,7 +6,7 @@ satellite_package: satellite
 satellite_scenario: satellite
 config_files_path: "{{ backup_dir }}/config_files.tar.gz"
 disable_firewall: False
-run_katello_reindex: False
+run_katello_reimport: False
 run_pre_install_check: True
 register_to_portal: False
 activationkey: changeme

--- a/roles/satellite-clone/tasks/main.yml
+++ b/roles/satellite-clone/tasks/main.yml
@@ -360,6 +360,6 @@
   - fail:
       msg: "Something went wrong! Please check the output above for more information."
 
-- name: "Run katello {{ verify_rake_task }} for Satellite - Note that this might take hours"
-  command: "foreman-rake katello:{{ verify_rake_task }} --trace"
-  when: run_katello_reindex or not clone_pulp_data_exists
+- name: "Run foreman-rake katello:reimport for Satellite - Note that this might take hours"
+  command: "foreman-rake katello:reimport --trace"
+  when: run_katello_reimport or not clone_pulp_data_exists

--- a/roles/satellite-clone/vars/satellite_6.6.yml
+++ b/roles/satellite-clone/vars/satellite_6.6.yml
@@ -1,7 +1,6 @@
 ---
 satellite_installer_options: "--foreman-ipa-authentication false --reset-puppet-server-ssl-chain-filepath --disable-system-checks"
 satellite_upgrade_options: "--upgrade --disable-system-checks"
-verify_rake_task: reimport
 db_packages:
   - postgresql-server
   - rh-mongodb34-syspaths

--- a/roles/satellite-clone/vars/satellite_6.7.yml
+++ b/roles/satellite-clone/vars/satellite_6.7.yml
@@ -1,7 +1,6 @@
 ---
 satellite_installer_options: "--foreman-ipa-authentication false --reset-puppet-server-ssl-chain-filepath --disable-system-checks"
 satellite_upgrade_options: "--upgrade --disable-system-checks"
-verify_rake_task: reimport
 db_packages:
   - postgresql-server
   - rh-mongodb34-syspaths

--- a/roles/satellite-clone/vars/satellite_6.8.yml
+++ b/roles/satellite-clone/vars/satellite_6.8.yml
@@ -1,7 +1,6 @@
 ---
 satellite_installer_options: "--foreman-ipa-authentication false --reset-puppet-server-ssl-chain-filepath --disable-system-checks"
 satellite_upgrade_options: "--disable-system-checks"
-verify_rake_task: reimport
 selinux_packages:
   - crane-selinux
   - foreman-selinux

--- a/roles/satellite-clone/vars/satellite_6.9.yml
+++ b/roles/satellite-clone/vars/satellite_6.9.yml
@@ -5,7 +5,6 @@
 # https://github.com/RedHatSatellite/satellite-clone/issues/349
 satellite_installer_options: "--foreman-ipa-authentication false --reset-puppet-server-ssl-chain-filepath --disable-system-checks"
 satellite_upgrade_options: "--disable-system-checks"
-verify_rake_task: reimport
 selinux_packages:
   - crane-selinux
   - foreman-selinux

--- a/satellite-clone-vars.sample.yml
+++ b/satellite-clone-vars.sample.yml
@@ -17,9 +17,9 @@
 # Disable firewall to setup Satellite for testing purposes. (defaults to false)
 #disable_firewall: false
 
-# Run katello reindex after the Satellite install. (defaults to false)
+# Run `foreman-rake katello:reimport` after the Satellite install. (defaults to false)
 # Note: If you are planning to clone your Satellite and immediately upgrade, you may choose to skip this step.
-#run_katello_reindex: false
+#run_katello_reimport: false
 
 # Run several pre-install checks (defaults to true)
 #run_pre_install_check: true


### PR DESCRIPTION
`foreman-rake katello:reindex` was previously replaced with
`foreman-rake katello:reimport`. Currently supported versions use
reimport only, so variables tracking which command must be used are dropped.
The variable previously named `run_katello_reindex` is also renamed to
be accurate to the currently supported Satellite versions.