### PR TITLE
Disassociate Capsule LCEs before foreman-rake katello:reimport

### DIFF
--- a/roles/satellite-clone/tasks/main.yml
+++ b/roles/satellite-clone/tasks/main.yml
@@ -275,10 +275,6 @@
   - name: Wait 60 seconds for services to be fully up
     wait_for: timeout=60
 
-  - name: "Run katello {{ verify_rake_task }} for Satellite - Note that this might take hours"
-    command: "foreman-rake katello:{{ verify_rake_task }} --trace"
-    when: run_katello_reindex or not clone_pulp_data_exists 
-
   - name: Disassociate capsules with lifecycle environments (to avoid the cloned Satellite server talking with live capsules)
     script: disassociate_capsules.rb {{ satellite_version }}
     register: disassociate_capsules
@@ -304,3 +300,7 @@
 
   - fail:
       msg: "Something went wrong! Please check the output above for more information."
+
+- name: "Run katello {{ verify_rake_task }} for Satellite - Note that this might take hours"
+  command: "foreman-rake katello:{{ verify_rake_task }} --trace"
+  when: run_katello_reindex or not clone_pulp_data_exists


### PR DESCRIPTION
If foreman-rake katello:reimport is run, it can potentially take hours.
Meanwhile the purpose of disassociating LCEs from Capsules is to prevent
accidental data modification. The Capsule LCE association relations are
independent of data that is reimported in reimport.rake. Therefore the
reimport should be run after Capsule LCE disassociation to prevent
unintended Capsule syncs while reimport is running.