### PR TITLE
only change EPEL if we're managing repos via `enable_repos`

### DIFF
--- a/roles/satellite-clone/tasks/main.yml
+++ b/roles/satellite-clone/tasks/main.yml
@@ -84,6 +84,7 @@
   yum_repository:
     name: epel
     state: absent
+  when: enable_repos
 
 - name: Clean yum info
   command: yum clean all


### PR DESCRIPTION
let's pretend people who manage their repos know what they are doing