### PR TITLE
ensure pulp user exists and owns /var/lib/pulp for 6.10+

### DIFF
--- a/roles/satellite-clone/tasks/ensure_pulp_data_permissions.yml
+++ b/roles/satellite-clone/tasks/ensure_pulp_data_permissions.yml
@@ -1,0 +1,30 @@
+---
+- name: 'Ensure pulp group exists'
+  group:
+    name: pulp
+    system: true
+
+- name: 'Ensure pulp user exists'
+  user:
+    name: pulp
+    group: pulp
+    create_home: false
+    home: /var/lib/pulp
+    shell: /sbin/nologin
+    system: true
+
+- name: 'Check /var/lib/pulp ownership'
+  stat:
+    path: /var/lib/pulp
+  register: pulp_stat
+
+- name: 'Correct ownership of /var/lib/pulp'
+  file:
+    path: /var/lib/pulp
+    state: directory
+    recurse: true
+    owner: pulp
+    group: pulp
+  when:
+    - pulp_stat.stat.exists
+    - pulp_stat.stat.pw_name != 'pulp' or pulp_stat.stat.gr_name != 'pulp'

--- a/roles/satellite-clone/tasks/main.yml
+++ b/roles/satellite-clone/tasks/main.yml
@@ -211,6 +211,12 @@
     state: present
   when: selinux_packages | length > 0
 
+- include_tasks: ensure_pulp_data_permissions.yml
+  when:
+    - not clone_pulp_data_exists
+    - not online_backup
+    - satellite_version in ["6.10", "7.0"]
+
 - name: untar config files (for cloning only)
   command: tar --selinux --overwrite -xf {{ backup_dir }}/config_files.tar.gz -C / --exclude=var/lib/foreman/public
 


### PR DESCRIPTION
in the case users utilize rsync instead of a backup with pulp data, they
might end up with /var/lib/pulp not being owned by pulp, let's fix that!