### PR TITLE
BZ#2102825 - detect when /var/lib/pulp is owned by an unknown user

### DIFF
--- a/roles/satellite-clone/tasks/ensure_pulp_data_permissions.yml
+++ b/roles/satellite-clone/tasks/ensure_pulp_data_permissions.yml
@@ -27,4 +27,4 @@
     group: pulp
   when:
     - pulp_stat.stat.exists
-    - pulp_stat.stat.pw_name != 'pulp' or pulp_stat.stat.gr_name != 'pulp'
+    - (pulp_stat.stat.pw_name is not defined or pulp_stat.stat.pw_name != 'pulp') or (pulp_stat.stat.gr_name is not defined or pulp_stat.stat.gr_name != 'pulp')


### PR DESCRIPTION
Sometimes, if you rsync `/var/lib/pulp` from a different machine, it ends
up being owned by a UID/GID that has no mapping on the new system.

Ansible's `stat` module then doesn't populate the `pw_name` and `gr_name`
attributes, leading to errors like this:

    error while evaluating conditional (pulp_stat.stat.pw_name != 'pulp' or pulp_stat.stat.gr_name != 'pulp'): 'dict object' has no attribute 'pw_name'

Catch those cases and still properly fix the permissions.