### PR TITLE
drop verify_rake_task definition from vars files

### DIFF
--- a/roles/satellite-clone/vars/satellite_6.10.yml
+++ b/roles/satellite-clone/vars/satellite_6.10.yml
@@ -4,7 +4,6 @@
 # https://github.com/RedHatSatellite/satellite-clone/issues/349
 satellite_installer_options: "--foreman-ipa-authentication false --reset-puppet-server-ssl-chain-filepath --disable-system-checks"
 satellite_upgrade_options: "--disable-system-checks"
-verify_rake_task: reimport
 selinux_packages:
   - foreman-selinux
   - katello-selinux

--- a/roles/satellite-clone/vars/satellite_6.11.yml
+++ b/roles/satellite-clone/vars/satellite_6.11.yml
@@ -4,7 +4,6 @@
 # https://github.com/RedHatSatellite/satellite-clone/issues/349
 satellite_installer_options: "--foreman-ipa-authentication false --reset-puppet-server-ssl-chain-filepath --disable-system-checks"
 satellite_upgrade_options: "--disable-system-checks"
-verify_rake_task: reimport
 selinux_packages:
   - foreman-selinux
   - katello-selinux

--- a/roles/satellite-clone/vars/satellite_6.12.yml
+++ b/roles/satellite-clone/vars/satellite_6.12.yml
@@ -4,7 +4,6 @@
 # https://github.com/RedHatSatellite/satellite-clone/issues/349
 satellite_installer_options: "--foreman-ipa-authentication false --reset-puppet-server-ssl-chain-filepath --disable-system-checks"
 satellite_upgrade_options: "--disable-system-checks"
-verify_rake_task: reimport
 selinux_packages:
   - foreman-selinux
   - katello-selinux


### PR DESCRIPTION
support for changing this was dropped in
b8908342d3797b37218d317e20de24d1d92c84b7, but those files were forgotten

Fixes: b8908342d3797b37218d317e20de24d1d92c84b7