### PR TITLE
enable only-builtns ansible-lint rule

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -8,3 +8,8 @@ warn_list:
   - risky-file-permissions
   - role-name
   - var-spacing
+enable_list:
+  - only-builtins
+only_builtins_allow_modules:
+  - get_value_from_yaml_in_tarball
+  - parse_backup_metadata


### PR DESCRIPTION
requires a release of ansible-lint with https://github.com/ansible/ansible-lint/pull/2732