### PR TITLE
do not enable the profile_tasks callback

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,4 @@
 [defaults]
-callbacks_enabled = profile_tasks
 inventory = $PWD/inventory
 log_path = $PWD/logs/playbook.log
 gathering = smart

--- a/ansible.production.cfg
+++ b/ansible.production.cfg
@@ -1,5 +1,4 @@
 [defaults]
-callbacks_enabled = profile_tasks
 inventory = /usr/share/satellite-clone/inventory
 log_path = /var/log/satellite-clone/playbook.log
 gathering = smart


### PR DESCRIPTION
it's not available in ansible-core and noone complained for it being missing since we moved to EL8