### PR TITLE
don't run installer again after we restored the backup

### DIFF
--- a/roles/satellite-clone/tasks/main.yml
+++ b/roles/satellite-clone/tasks/main.yml
@@ -312,11 +312,6 @@
       create: yes
       line: "---\n:foreman:\n  :username: admin\n  :password: changeme"
 
-  - name: Run installer upgrade to match latest z-version
-    command: '{{ satellite_installer_cmd }} {{ satellite_upgrade_options | default("") }}'
-    environment:
-      HOSTNAME: "{{ hostname }}"
-
   - name: Test Satellite
     command: hammer ping
 


### PR DESCRIPTION
foreman-maintain runs the installer after the restore for us, no need to repeat things

saves about a minute in my tests :)