### PR TITLE
use hostname from metadata

### DIFF
--- a/roles/satellite-clone/library/parse_backup_metadata.py
+++ b/roles/satellite-clone/library/parse_backup_metadata.py
@@ -48,6 +48,8 @@ def parse_backup_metadata(params):
     puppetserver_present = bool(find_rpm(rpms, "^puppetserver-[\d+].*"))
     qpidd_present = bool(find_rpm(rpms, "^qpid-cpp-server-[\d+].*"))
 
+    hostname = data['hostname']
+
     if not satellite_version:
         satellite_version = os.getenv('SATELLITE_CLONE_FORCE_VERSION')
 
@@ -60,6 +62,7 @@ def parse_backup_metadata(params):
     result = dict(satellite_version=satellite_version,
                   puppetserver_present=puppetserver_present,
                   qpidd_present=qpidd_present,
+                  hostname=hostname,
                   msg=msg,
                   changed=False)
     return True, result

--- a/roles/satellite-clone/tasks/backup_satellite_version_check.yml
+++ b/roles/satellite-clone/tasks/backup_satellite_version_check.yml
@@ -21,6 +21,7 @@
     satellite_version: "{{ backup_metadata.satellite_version }}"
     puppetserver_present: "{{ backup_metadata.puppetserver_present }}"
     qpidd_present: "{{ backup_metadata.qpidd_present }}"
+    hostname: "{{ backup_metadata.hostname }}"
   when:
     - clone_metadata_exists
     - backup_metadata is defined

--- a/roles/satellite-clone/tasks/main.yml
+++ b/roles/satellite-clone/tasks/main.yml
@@ -26,21 +26,10 @@
       paths:
         - "vars"
 
-- name: Identify the hostname from the backup config tar file
-  get_value_from_yaml_in_tarball:
-    tarball: "{{ config_files_path }}"
-    target_file: "etc/foreman-proxy/settings.yml"
-    keys: [":foreman_url"]
-  register: backup_hostname
-
-- name: Set backup_hostname variable
-  set_fact:
-    hostname: "{{ backup_hostname.value | urlsplit('hostname') }}"
-
 - name: Check that the hostname is not none
   fail:
-    msg: "Unable to derive Satellite hostname from the backup config file - value ({{ hostname }}) doesn't look right"
-  when: backup_hostname|length == 0
+    msg: "Unable to derive Satellite hostname from the backup metadata file - value ({{ hostname }}) doesn't look right"
+  when: hostname|length == 0
 
 - name: Check that the registration variables (activationkey, org) are updated
   fail:


### PR DESCRIPTION
no need to parse URLs

this exists since https://github.com/theforeman/foreman_maintain/commit/bb692bd7f3859ad7834c3c71f1c2c8b989b14c9a which is safe to assume to be present in every backup out there