### PR TITLE
Remove use of get_md5 parameter in stat module

### DIFF
--- a/roles/satellite-clone/tasks/backup_check.yml
+++ b/roles/satellite-clone/tasks/backup_check.yml
@@ -3,7 +3,6 @@
   stat:
     path: '{{ backup_dir }}/config_files.tar.gz'
     get_checksum: False
-    get_md5: False
   register: config_data
 
 - name: set fact - config_data
@@ -14,7 +13,6 @@
   stat:
     path: '{{ backup_dir }}/pgsql_data.tar.gz'
     get_checksum: False
-    get_md5: False
   register: pgsql_data
 
 - name: set fact - pgsql_data
@@ -25,7 +23,6 @@
   stat:
     path: '{{ backup_dir }}/pulp_data.tar'
     get_checksum: False
-    get_md5: False
   register: pulp_data
 
 - name: set fact - pulp_data
@@ -36,7 +33,6 @@
   stat:
     path: '{{ backup_dir }}/foreman.dump'
     get_checksum: False
-    get_md5: False
   register: foreman_dump
 
 - name: set fact - foreman_dump
@@ -47,7 +43,6 @@
   stat:
     path: "{{ backup_dir }}/candlepin.dump"
     get_checksum: False
-    get_md5: False
   register: candlepin_dump
 
 - name: set fact - candlepin_dump
@@ -58,7 +53,6 @@
   stat:
     path: "{{ backup_dir }}/pulpcore.dump"
     get_checksum: False
-    get_md5: False
   register: pulpcore_dump
 
 - name: set fact - pulpcore_dump

--- a/roles/satellite-clone/tasks/backup_satellite_version_check.yml
+++ b/roles/satellite-clone/tasks/backup_satellite_version_check.yml
@@ -3,7 +3,6 @@
   stat:
     path: "{{ backup_dir }}/metadata.yml"
     get_checksum: False
-    get_md5: False
   register: metadata
 
 - name: set fact - metadata


### PR DESCRIPTION
https://github.com/ansible/ansible/commit/d955fb1590efaaf996d7a48746e15f71cc65f583 removed the use of this parameter. Anything on RHEL8.10 will have an updated version of ansible, so this currently causes satellite-clone to fail on 8.10.